### PR TITLE
Separate debug & release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,10 @@ This project is trying to use the latest Android tech stacks.
 ## Building
 
 To build this project, you need the latest stable
-of [Android Studio](https://developer.android.com/studio) and a signing key `*.jks`.
+of [Android Studio](https://developer.android.com/studio).
 
 1. Clone the project and open in Android Studio.
-2. Create a file named `signing.properties` inside the root directory, then add this signing
-   information:
-
-```properties
-STORE_FILE=<PATH TO STORE FILE>
-STORE_PASSWORD=<STORE PASSWORD>
-KEY_ALIAS=<KEY ALIAS>
-KEY_PASSWORD=<KEY PASSWORD>
-```
-
-3. Sync project with Gradle then Run 'app'.
+2. Sync project with Gradle then Run 'app'.
 
 ## License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,18 +23,6 @@ android {
         }
     }
 
-    signingConfigs {
-        debug {
-            Properties properties = new Properties()
-            properties.load(project.rootProject.file("signing.properties").newDataInputStream())
-
-            storeFile file(properties.getProperty("STORE_FILE"))
-            keyAlias properties.getProperty("KEY_ALIAS")
-            storePassword properties.getProperty("STORE_PASSWORD")
-            keyPassword properties.getProperty("KEY_PASSWORD")
-        }
-    }
-
     buildTypes {
         release {
             minifyEnabled true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".dev"
+        }
+
         release {
             minifyEnabled true
             shrinkResources true

--- a/core/resources/src/debug/res/values/strings.xml
+++ b/core/resources/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name" translatable="false">Mikansei (Dev)</string>
+</resources>


### PR DESCRIPTION
The building instruction is now simpler without requiring a signing key for debug build. The debug build is now under a different app name and package name to avoid signature mismatch.

Summary of changes:
- Removed debug build signing config requirements.
- Added suffix for debug build package name from `com.uragiristereo.mikansei` to `com.uragiristereo.mikansei.dev`.
- Used a different app name for debug build from `Mikansei` to `Mikansei (Dev)`.
- Updated the README's building instruction part.