### PR TITLE
Implement Firebase Crashlytics on a different product flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ of [Android Studio](https://developer.android.com/studio).
 1. Clone the project and open in Android Studio.
 2. Sync project with Gradle then Run 'app'.
 
+Note: the `play` build variant will bundle Firebase Crashlytics to the app. By default it will use
+the `oss` build variant. The `oss` build variant won't bundle Firebase at all. To use the `play`
+build variant, you need to create 2 Firebase apps:
+
+For production/release build, create a Firebase Android app with `com.uragiristereo.mikansei` as the
+package name. And store the `google-services.json` file in this path:
+
+```
+~/app/src/play/release/
+```
+
+For dev/debug build, create a Firebase Android app with `com.uragiristereo.mikansei.dev` as the
+package name. And store the `google-services.json` file in this path:
+
+```
+~/app/src/play/debug/
+```
+
 ## License
 
     Copyright 2023 Agung Watanabe

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.gms)
+    alias(libs.plugins.firebase.crashlytics)
 }
 
 android {
@@ -101,4 +103,9 @@ dependencies {
 
     // Safer Navigation Compose
     implementation(libs.safer.navigation.compose)
+
+    // Firebase
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,13 @@ android {
         }
     }
 
+    applicationVariants.configureEach { variant ->
+        // Enables GMS on play build variant
+        tasks.named("process${variant.name.capitalize()}GoogleServices").configure {
+            enabled = variant.flavorName == "play"
+        }
+    }
+
     buildFeatures {
         compose true
     }
@@ -117,7 +124,7 @@ dependencies {
     implementation(libs.safer.navigation.compose)
 
     // Firebase
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.analytics)
-    implementation(libs.firebase.crashlytics)
+    playImplementation(platform(libs.firebase.bom))
+    playImplementation(libs.firebase.analytics)
+    playImplementation(libs.firebase.crashlytics)
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,18 @@ android {
         }
     }
 
+    flavorDimensions.add("env")
+
+    productFlavors {
+        oss {
+            dimension "env"
+        }
+
+        play {
+            dimension "env"
+        }
+    }
+
     buildFeatures {
         compose true
     }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="firebase_analytics_collection_deactivated"
+            android:value="true" />
+    </application>
+</manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.gms) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }
 
 tasks.register('clean', Delete) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ okhttp = "5.0.0-alpha.11"
 retrofit = "2.9.0"
 safer-navigation-compose = "860e4afc2f"
 media3 = "1.1.1"
+gms = "4.4.0"
+firebase-bom = "32.5.0"
+firebase-crashlytics = "2.9.9"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle" }
@@ -21,6 +24,8 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+gms = { id = "com.google.gms.google-services", version.ref = "gms" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics" }
 
 
 [libraries]
@@ -86,6 +91,11 @@ safer-navigation-compose = { module = "com.github.uragiristereo.safer-navigation
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 media3-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "media3" }
 media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
+
+# Firebase
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 
 
 [bundles]


### PR DESCRIPTION
Soon after the first release the app will have crashlytics. But first we need to make sure other contribute can build the project without hassle. To do that I made 2 different product flavor, one without crashlytics (oss) and one with crashlytics (play). It will use the "oss" product flavor by default. The signed & released app then will always use the "play" product flavor.

Summary of changes:
- Added the required dependencies
- Add 2 separate product flavors
- Enable crashlytics only on debug "play" product flavor
- Update the build instruction on README