### PR TITLE
Replace Safer Navigation Compose with Serialized Navigation Extension

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     implementation(libs.bundles.coil)
     implementation(libs.timber)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.safer.navigation.compose)
+    implementation(libs.serialized.navigation.extension.serializer.kotlinx)
     playImplementation(platform(libs.firebase.bom))
     playImplementation(libs.firebase.analytics)
     playImplementation(libs.firebase.crashlytics)

--- a/app/src/main/java/com/uragiristereo/mikansei/MikanseiApp.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/MikanseiApp.kt
@@ -8,6 +8,8 @@ import android.os.Build.VERSION.SDK_INT
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import com.uragiristereo.mikansei.core.domain.module.network.NetworkRepository
+import com.uragiristereo.serializednavigationextension.runtime.installSerializer
+import com.uragiristereo.serializednavigationextension.serializer.KotlinxSerializer
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.component.KoinComponent
@@ -22,6 +24,7 @@ class MikanseiApp : Application(), ImageLoaderFactory, KoinComponent {
         super.onCreate()
 
         Timber.plant(Timber.DebugTree())
+        installSerializer(KotlinxSerializer())
 
         if (SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel("downloads", "Downloads", NotificationManager.IMPORTANCE_LOW)

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/MainScreen.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/MainScreen.kt
@@ -20,9 +20,6 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -52,6 +49,9 @@ import com.uragiristereo.mikansei.core.ui.rememberWindowSizeVertical
 import com.uragiristereo.mikansei.ui.content.MainContentResponsive
 import com.uragiristereo.mikansei.ui.core.ShareDownloadDialog
 import com.uragiristereo.mikansei.ui.navgraphs.BottomNavGraph
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.navigate
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import java.util.UUID
@@ -133,7 +133,7 @@ fun MainScreen(
     }
 
     BackHandler(
-        enabled = viewModel.confirmExit && currentRoute == MainRoute.Home::class.route,
+        enabled = viewModel.confirmExit && currentRoute == routeOf<MainRoute.Home>(),
         onBack = remember {
             {
                 scope.launch {
@@ -155,7 +155,7 @@ fun MainScreen(
     )
 
     BackHandler(
-        enabled = !viewModel.confirmExit && currentRoute == MainRoute.Home::class.route,
+        enabled = !viewModel.confirmExit && currentRoute == routeOf<MainRoute.Home>(),
         onBack = {
             (context as Activity).finishAffinity()
         },
@@ -208,9 +208,8 @@ fun MainScreen(
                 )
             }
 
-            val navigationBarsVisible = when {
-                currentRoute in HomeRoutesString -> true
-                currentRoute == null -> true
+            val navigationBarsVisible = when (currentRoute) {
+                in HomeRoutesString, null -> true
                 else -> false
             }
 

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/appbars/MainBottomNavigationBar.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/appbars/MainBottomNavigationBar.kt
@@ -14,13 +14,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.ui.composable.NavigationBarSpacer
 import com.uragiristereo.mikansei.core.ui.extension.backgroundElevation
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoutesString
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.route
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 
 @Composable
 fun MainBottomNavigationBar(
@@ -56,7 +57,7 @@ fun MainBottomNavigationBar(
             contentColor = MaterialTheme.colors.primary,
         ) {
             MainNavigationItems.entries.forEach { item ->
-                val itemRouteString = item.route::class.route
+                val itemRouteString = item.route.route
                 val currentRouteIsItem = currentRoute == itemRouteString
                 val previousRouteIsItem = previousRoute == itemRouteString
 
@@ -82,10 +83,10 @@ fun MainBottomNavigationBar(
                     onClick = {
                         when {
                             listOf(item.route.route, currentRoute).all {
-                                it == HomeRoute.Posts::class.route
+                                it == routeOf<HomeRoute.Posts>()
                             } -> onRequestScrollToTop()
 
-                            item.route.route == MainRoute.Search::class.route -> onNavigateSearch()
+                            item.route.route == routeOf<MainRoute.Search>() -> onNavigateSearch()
                             else -> onNavigate(item.route)
                         }
                     },

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/appbars/MainNavigationItems.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/appbars/MainNavigationItems.kt
@@ -3,10 +3,10 @@ package com.uragiristereo.mikansei.ui.appbars
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Stable
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
 import com.uragiristereo.mikansei.core.resources.R
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
 
 @Stable
 enum class MainNavigationItems(

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/appbars/MainNavigationRail.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/appbars/MainNavigationRail.kt
@@ -12,12 +12,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.ui.extension.backgroundElevation
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoutesString
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.route
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 
 @Composable
 fun MainNavigationRail(
@@ -38,7 +39,7 @@ fun MainNavigationRail(
             modifier = Modifier.fillMaxHeight(),
         ) {
             MainNavigationItems.entries.forEach { item ->
-                val itemRouteString = item.route::class.route
+                val itemRouteString = item.route.route
                 val currentRouteIsItem = currentRoute == itemRouteString
                 val previousRouteIsItem = previousRoute == itemRouteString
 
@@ -64,10 +65,10 @@ fun MainNavigationRail(
                     onClick = {
                         when {
                             listOf(item.route.route, currentRoute).all {
-                                it == HomeRoute.Posts::class.route
+                                it == routeOf<HomeRoute.Posts>()
                             } -> onRequestScrollToTop()
 
-                            item.route.route == MainRoute.Search::class.route -> onNavigateSearch()
+                            item.route.route == routeOf<MainRoute.Search>() -> onNavigateSearch()
                             else -> onNavigate(item.route)
                         }
                     },

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/content/MainContentCompact.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/content/MainContentCompact.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
 import com.google.accompanist.insets.ui.Scaffold
 import com.uragiristereo.mikansei.core.ui.LocalMainScaffoldPadding
 import com.uragiristereo.mikansei.ui.appbars.MainBottomNavigationBar
 import com.uragiristereo.mikansei.ui.navgraphs.MainNavGraph
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
 
 @Composable
 fun MainContentCompact(

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/content/MainContentMediumWide.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/content/MainContentMediumWide.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.ui.LocalMainScaffoldPadding
 import com.uragiristereo.mikansei.core.ui.composable.DimensionSubcomposeLayout
 import com.uragiristereo.mikansei.core.ui.composable.RailScaffold
@@ -40,6 +38,8 @@ import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.ui.appbars.MainNavigationRail
 import com.uragiristereo.mikansei.ui.navgraphs.MainNavGraph
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 
 @Composable
 fun MainContentMediumWide(
@@ -118,8 +118,8 @@ fun MainContentMediumWide(
                 MainNavGraph(navController = navController)
 
                 if (currentRoute !in listOf(
-                        MainRoute.Image::class.route,
-                        HomeRoute.Posts::class.route
+                        routeOf<MainRoute.Image>(),
+                        routeOf<HomeRoute.Posts>(),
                     )
                 ) {
                     Spacer(

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/content/MainContentResponsive.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/content/MainContentResponsive.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
 import com.uragiristereo.mikansei.core.ui.LocalWindowSizeHorizontal
 import com.uragiristereo.mikansei.core.ui.WindowSize
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
 
 @Composable
 fun MainContentResponsive(

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/navgraphs/MainNavGraph.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/navgraphs/MainNavGraph.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.NavHost
 import com.uragiristereo.mikansei.core.ui.animation.translateXFadeIn
 import com.uragiristereo.mikansei.core.ui.animation.translateXFadeOut
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
@@ -16,6 +15,7 @@ import com.uragiristereo.mikansei.feature.search.core.searchRoute
 import com.uragiristereo.mikansei.feature.settings.core.settingsGraph
 import com.uragiristereo.mikansei.feature.user.userGraph
 import com.uragiristereo.mikansei.ui.MainViewModel
+import com.uragiristereo.serializednavigationextension.navigation.compose.NavHost
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -26,7 +26,7 @@ fun MainNavGraph(
 ) {
     NavHost(
         navController = navController,
-        startDestination = MainRoute.Home::class,
+        startDestination = MainRoute.Home,
         enterTransition = {
             translateXFadeIn(forward = true)
         },

--- a/core/product/build.gradle
+++ b/core/product/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug)
     implementation(libs.timber)
     implementation(libs.bundles.koin)
-    implementation(libs.safer.navigation.compose)
 }

--- a/core/product/src/main/java/com/uragiristereo/mikansei/core/product/shared/postfavoritevote/PostFavoriteVoteImpl.kt
+++ b/core/product/src/main/java/com/uragiristereo/mikansei/core/product/shared/postfavoritevote/PostFavoriteVoteImpl.kt
@@ -7,13 +7,13 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.PostVote
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Profile
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -28,7 +28,7 @@ open class PostFavoriteVoteImpl : ViewModel(), PostFavoriteVote, KoinComponent {
     private val activeUser: Profile
         get() = userRepository.active.value
 
-    override var post = savedStateHandle.getData<MainRoute.Image>()!!.post
+    override var post = savedStateHandle.navArgsOf<MainRoute.Image>()!!.post
 
     private val post2 by lazy { post }
 

--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -32,6 +32,6 @@ dependencies {
     api(libs.accompanist.insets.ui)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
+    api(libs.serialized.navigation.extension.compose)
     implementation(libs.bundles.coil)
 }

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/HomeRoute.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/HomeRoute.kt
@@ -1,9 +1,9 @@
 package com.uragiristereo.mikansei.core.ui.navigation
 
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Favorite
 import com.uragiristereo.mikansei.core.model.danbooru.Post
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 import kotlinx.serialization.Serializable
 
 sealed interface HomeRoute : NavRoute {
@@ -12,9 +12,11 @@ sealed interface HomeRoute : NavRoute {
         val tags: String = "",
     ) : HomeRoute
 
-    object Favorites : HomeRoute
+    @Serializable
+    data object Favorites : HomeRoute
 
-    object More : HomeRoute
+    @Serializable
+    data object More : HomeRoute
 
     @Serializable
     data class PostMore(
@@ -53,7 +55,7 @@ sealed interface HomeRoute : NavRoute {
 
 val HomeRoutesString: List<String>
     get() = listOf(
-        HomeRoute.Posts::class.route,
-        HomeRoute.Favorites::class.route,
-        HomeRoute.More::class.route,
+        routeOf<HomeRoute.Posts>(),
+        routeOf<HomeRoute.Favorites>(),
+        routeOf<HomeRoute.More>(),
     )

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/MainRoute.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/MainRoute.kt
@@ -1,12 +1,13 @@
 package com.uragiristereo.mikansei.core.ui.navigation
 
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.model.danbooru.Post
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 import kotlinx.serialization.Serializable
 
 sealed interface MainRoute : NavRoute {
-    object Home : MainRoute
+    @Serializable
+    data object Home : MainRoute
 
     @Serializable
     data class Search(
@@ -18,17 +19,23 @@ sealed interface MainRoute : NavRoute {
         val post: Post,
     ) : MainRoute
 
-    object Settings : MainRoute
+    @Serializable
+    data object Settings : MainRoute
 
-    object Filters : MainRoute
+    @Serializable
+    data object Filters : MainRoute
 
-    object SearchHistory : MainRoute
+    @Serializable
+    data object SearchHistory : MainRoute
 
-    object SavedSearches : MainRoute
+    @Serializable
+    data object SavedSearches : MainRoute
 
-    object About : MainRoute
+    @Serializable
+    data object About : MainRoute
 
-    object User : MainRoute
+    @Serializable
+    data object User : MainRoute
 
     @Serializable
     data class NewFavGroup(
@@ -37,7 +44,7 @@ sealed interface MainRoute : NavRoute {
 }
 
 val NestedNavigationRoutes = listOf(
-    MainRoute.Home.route,
-    MainRoute.Settings.route,
-    MainRoute.User.route,
+    routeOf<MainRoute.Home>(),
+    routeOf<MainRoute.Settings>(),
+    routeOf<MainRoute.User>(),
 )

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/SettingsRoute.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/SettingsRoute.kt
@@ -1,7 +1,9 @@
 package com.uragiristereo.mikansei.core.ui.navigation
 
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import kotlinx.serialization.Serializable
 
 sealed interface SettingsRoute : NavRoute {
-    object Index : NavRoute
+    @Serializable
+    data object Index : SettingsRoute
 }

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/UserRoute.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/UserRoute.kt
@@ -1,13 +1,18 @@
 package com.uragiristereo.mikansei.core.ui.navigation
 
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import kotlinx.serialization.Serializable
 
 sealed interface UserRoute : NavRoute {
-    object Login : UserRoute
+    @Serializable
+    data object Login : UserRoute
 
-    object Manage : UserRoute
+    @Serializable
+    data object Manage : UserRoute
 
-    object Settings : UserRoute
+    @Serializable
+    data object Settings : UserRoute
 
-    object Switch : UserRoute
+    @Serializable
+    data object Switch : UserRoute
 }

--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -27,5 +27,4 @@ dependencies {
     implementation(libs.bundles.compose)
     implementation(libs.bundles.androidx.compose)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/about/src/main/java/com/uragiristereo/mikansei/feature/about/core/AboutNavigation.kt
+++ b/feature/about/src/main/java/com/uragiristereo/mikansei/feature/about/core/AboutNavigation.kt
@@ -2,19 +2,16 @@ package com.uragiristereo.mikansei.feature.about.core
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.about.AboutScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
 
 fun NavGraphBuilder.aboutRoute(
     navController: NavHostController,
 ) {
-    composable(
-        route = MainRoute.About,
-        content = {
-            AboutScreen(
-                onNavigateBack = navController::navigateUp,
-            )
-        },
-    )
+    composable<MainRoute.About> {
+        AboutScreen(
+            onNavigateBack = navController::navigateUp,
+        )
+    }
 }

--- a/feature/filters/build.gradle
+++ b/feature/filters/build.gradle
@@ -30,5 +30,4 @@ dependencies {
     implementation(libs.bundles.androidx.compose)
     implementation(libs.bundles.koin)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/filters/src/main/java/com/uragiristereo/mikansei/feature/filters/core/FiltersNavigation.kt
+++ b/feature/filters/src/main/java/com/uragiristereo/mikansei/feature/filters/core/FiltersNavigation.kt
@@ -2,19 +2,16 @@ package com.uragiristereo.mikansei.feature.filters.core
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.filters.FiltersScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
 
 fun NavGraphBuilder.filtersRoute(
     navController: NavHostController,
 ) {
-    composable(
-        route = MainRoute.Filters,
-        content = {
-            FiltersScreen(
-                onNavigateBack = navController::navigateUp,
-            )
-        },
-    )
+    composable<MainRoute.Filters> {
+        FiltersScreen(
+            onNavigateBack = navController::navigateUp,
+        )
+    }
 }

--- a/feature/home/build.gradle
+++ b/feature/home/build.gradle
@@ -34,5 +34,4 @@ dependencies {
     implementation(libs.bundles.androidx.compose)
     implementation(libs.bundles.koin)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/home/favorites/build.gradle
+++ b/feature/home/favorites/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation(libs.bundles.core)
     implementation(libs.bundles.coil)
     implementation(libs.bundles.koin)
-    implementation(libs.safer.navigation.compose)
     implementation(libs.androidx.browser)
     implementation(libs.kotlinx.serialization.json)
 }

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/FavoritesModule.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/FavoritesModule.kt
@@ -6,9 +6,6 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.ui.extension.rememberParentViewModelStoreOwner
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.LocalBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
@@ -22,6 +19,9 @@ import com.uragiristereo.mikansei.feature.home.favorites.favgroup.more.FavGroupM
 import com.uragiristereo.mikansei.feature.home.favorites.favgroup.more.FavGroupMoreViewModel
 import com.uragiristereo.mikansei.feature.home.favorites.favgroup.new.NewFavGroupScreen
 import com.uragiristereo.mikansei.feature.home.favorites.favgroup.new.NewFavGroupViewModel
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigate
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
@@ -40,7 +40,7 @@ fun NavGraphBuilder.favoritesRoute(navController: NavHostController) {
 
         val homeViewModelStoreOwner = rememberParentViewModelStoreOwner(
             navController = navController,
-            parentRoute = MainRoute.Home.route,
+            parentRoute = routeOf<MainRoute.Home>(),
         )
 
         CompositionLocalProvider(LocalViewModelStoreOwner provides homeViewModelStoreOwner) {
@@ -67,10 +67,10 @@ fun NavGraphBuilder.favoritesRoute(navController: NavHostController) {
         }
     }
 
-    composable(route = MainRoute.NewFavGroup()) {
+    composable(defaultValue = MainRoute.NewFavGroup()) {
         val homeViewModelStoreOwner = rememberParentViewModelStoreOwner(
             navController = navController,
-            parentRoute = MainRoute.Home.route,
+            parentRoute = routeOf<MainRoute.Home>(),
         )
 
         val favoritesViewModel: FavoritesViewModel = koinViewModel(viewModelStoreOwner = homeViewModelStoreOwner)
@@ -84,7 +84,7 @@ fun NavGraphBuilder.favoritesRoute(navController: NavHostController) {
     composable<HomeRoute.EditFavoriteGroup> {
         val homeViewModelStoreOwner = rememberParentViewModelStoreOwner(
             navController = navController,
-            parentRoute = MainRoute.Home.route,
+            parentRoute = routeOf<MainRoute.Home>(),
         )
 
         val favoritesViewModel: FavoritesViewModel = koinViewModel(viewModelStoreOwner = homeViewModelStoreOwner)
@@ -111,10 +111,12 @@ fun NavGraphBuilder.favoritesBottomRoute(navController: NavHostController) {
         )
     }
 
-    composable<HomeRoute.FavoriteGroupMore> { data ->
-        if (data != null) {
+    composable<HomeRoute.FavoriteGroupMore> {
+        val args = rememberNavArgsOf()
+
+        if (args != null) {
             val bottomSheetNavigator = LocalBottomSheetNavigator.current
-            val favoriteGroup = data.favoriteGroup
+            val favoriteGroup = args.favoriteGroup
 
             FavGroupMoreContent(
                 onDismiss = bottomSheetNavigator.bottomSheetState::hide,
@@ -142,22 +144,23 @@ fun NavGraphBuilder.favoritesBottomRoute(navController: NavHostController) {
         }
     }
 
-    composable<HomeRoute.DeleteFavoriteGroup> { data ->
+    composable<HomeRoute.DeleteFavoriteGroup> {
         val bottomSheetNavigator = LocalBottomSheetNavigator.current
+        val args = rememberNavArgsOf()
 
         val homeViewModelStoreOwner = rememberParentViewModelStoreOwner(
             navController = navController,
-            parentRoute = MainRoute.Home.route,
+            parentRoute = routeOf<MainRoute.Home>(),
         )
 
         val favoritesViewModel: FavoritesViewModel = koinViewModel(viewModelStoreOwner = homeViewModelStoreOwner)
 
-        if (data != null) {
+        if (args != null) {
             DeleteFavGroupContent(
-                favoriteGroup = data.favoriteGroup,
+                favoriteGroup = args.favoriteGroup,
                 onDeleteClick = {
                     bottomSheetNavigator.runHiding {
-                        favoritesViewModel.deleteFavoriteGroup(data.favoriteGroup)
+                        favoritesViewModel.deleteFavoriteGroup(args.favoriteGroup)
                     }
                 },
             )

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/addto/AddToFavGroupViewModel.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/addto/AddToFavGroupViewModel.kt
@@ -7,13 +7,13 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Favorite
 import com.uragiristereo.mikansei.core.domain.usecase.GetFavoriteGroupsUseCase
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.feature.home.favorites.favgroup.addto.core.FavoriteGroup
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -24,7 +24,7 @@ class AddToFavGroupViewModel(
     private val danbooruRepository: DanbooruRepository,
     private val getFavoriteGroupsUseCase: GetFavoriteGroupsUseCase,
 ) : ViewModel() {
-    val post = checkNotNull(savedStateHandle.getData<HomeRoute.AddToFavGroup>()).post
+    val post = checkNotNull(savedStateHandle.navArgsOf<HomeRoute.AddToFavGroup>()).post
 
     var items by mutableStateOf<List<FavoriteGroup>>(listOf())
         private set

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/edit/EditFavGroupViewModel.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/edit/EditFavGroupViewModel.kt
@@ -11,12 +11,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
 import androidx.lifecycle.viewmodel.compose.saveable
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.ui.extension.strip
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.feature.home.favorites.favgroup.new.core.FabState
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -26,7 +26,7 @@ class EditFavGroupViewModel(
     savedStateHandle: SavedStateHandle,
     private val danbooruRepository: DanbooruRepository,
 ) : ViewModel() {
-    private val navArgs = checkNotNull(savedStateHandle.getData<HomeRoute.EditFavoriteGroup>())
+    private val navArgs = checkNotNull(savedStateHandle.navArgsOf<HomeRoute.EditFavoriteGroup>())
     val favoriteGroup = navArgs.favoriteGroup
     private val spaceSeparatedPostIds = favoriteGroup.postIds.joinToString(separator = " ")
 

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/new/NewFavGroupViewModel.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/new/NewFavGroupViewModel.kt
@@ -10,12 +10,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
 import androidx.lifecycle.viewmodel.compose.saveable
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.usecase.GetFavoriteGroupsUseCase
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.home.favorites.favgroup.new.core.FabState
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
@@ -29,7 +29,7 @@ class NewFavGroupViewModel(
     private val danbooruRepository: DanbooruRepository,
     private val getFavoriteGroupsUseCase: GetFavoriteGroupsUseCase,
 ) : ViewModel() {
-    val postId = savedStateHandle.getData(MainRoute.NewFavGroup()).postId
+    val postId = savedStateHandle.navArgsOf(MainRoute.NewFavGroup()).postId
 
     private val channel = Channel<Event>()
     val event = channel.receiveAsFlow()

--- a/feature/home/more/build.gradle
+++ b/feature/home/more/build.gradle
@@ -32,5 +32,4 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug)
     implementation(libs.bundles.koin)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/home/more/src/main/java/com/uragiristereo/mikansei/feature/home/more/MoreScreen.kt
+++ b/feature/home/more/src/main/java/com/uragiristereo/mikansei/feature/home/more/MoreScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
 import com.uragiristereo.mikansei.core.product.component.ProductStatusBarSpacer
 import com.uragiristereo.mikansei.core.resources.R
 import com.uragiristereo.mikansei.core.ui.LocalMainScaffoldPadding
@@ -47,6 +46,7 @@ import com.uragiristereo.mikansei.core.ui.navigation.UserRoute
 import com.uragiristereo.mikansei.feature.home.more.core.MoreTopAppBar
 import com.uragiristereo.mikansei.feature.home.more.core.NavigationItem
 import com.uragiristereo.mikansei.feature.home.more.core.UserHeader
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
 import org.koin.androidx.compose.koinViewModel
 
 @Composable

--- a/feature/home/more/src/main/java/com/uragiristereo/mikansei/feature/home/more/core/MoreNavigation.kt
+++ b/feature/home/more/src/main/java/com/uragiristereo/mikansei/feature/home/more/core/MoreNavigation.kt
@@ -2,29 +2,26 @@ package com.uragiristereo.mikansei.feature.home.more.core
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.InterceptBackGestureForBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.LocalBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.feature.home.more.MoreScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 
 fun NavGraphBuilder.moreRoute(mainNavController: NavHostController) {
-    composable(
-        route = HomeRoute.More,
-        content = {
-            val bottomSheetNavigator = LocalBottomSheetNavigator.current
+    composable<HomeRoute.More> {
+        val bottomSheetNavigator = LocalBottomSheetNavigator.current
 
-            InterceptBackGestureForBottomSheetNavigator()
+        InterceptBackGestureForBottomSheetNavigator()
 
-            MoreScreen(
-                onNavigate = mainNavController::navigate,
-                onNavigateBottom = { route ->
-                    bottomSheetNavigator.navigate {
-                        it.navigate(route)
-                    }
-                },
-            )
-        },
-    )
+        MoreScreen(
+            onNavigate = mainNavController::navigate,
+            onNavigateBottom = { route ->
+                bottomSheetNavigator.navigate {
+                    it.navigate(route)
+                }
+            },
+        )
+    }
 }

--- a/feature/home/posts/build.gradle
+++ b/feature/home/posts/build.gradle
@@ -37,5 +37,4 @@ dependencies {
     implementation(libs.bundles.coil)
     implementation(libs.timber)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/PostsViewModel.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/PostsViewModel.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
 import androidx.lifecycle.viewmodel.compose.saveable
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.database.session.SessionDao
 import com.uragiristereo.mikansei.core.database.session.toSessionList
 import com.uragiristereo.mikansei.core.domain.usecase.GetPostsUseCase
@@ -24,6 +23,7 @@ import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.feature.home.posts.state.PostsContentState
 import com.uragiristereo.mikansei.feature.home.posts.state.PostsLoadingState
 import com.uragiristereo.mikansei.feature.home.posts.state.PostsSavedState
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -37,7 +37,7 @@ class PostsViewModel(
     private val getPostsUseCase: GetPostsUseCase,
     private val sessionDao: SessionDao,
 ) : ViewModel() {
-    val tags = savedStateHandle.getData<HomeRoute.Posts>()?.tags ?: ""
+    val tags = savedStateHandle.navArgsOf<HomeRoute.Posts>()?.tags ?: ""
 
     var topAppBarHeight by mutableStateOf(0.dp)
     val offsetY = Animatable(initialValue = 0f)

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/core/PostsNavigation.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/core/PostsNavigation.kt
@@ -8,9 +8,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnDownload
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnShare
@@ -21,6 +18,9 @@ import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.home.posts.PostsScreen
 import com.uragiristereo.mikansei.feature.home.posts.more.PostMoreContent
 import com.uragiristereo.mikansei.feature.home.posts.share.ShareContent
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigate
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 
 @SuppressLint("RestrictedApi")
 fun NavGraphBuilder.postsRoute(
@@ -37,10 +37,10 @@ fun NavGraphBuilder.postsRoute(
     }
 
     composable(
-        route = HomeRoute.Posts(),
+        defaultValue = HomeRoute.Posts(),
         enterTransition = {
             when (initialState.destination.route) {
-                HomeRoute.Posts::class.route -> slideIntoContainer(
+                routeOf<HomeRoute.Posts>() -> slideIntoContainer(
                     towards = AnimatedContentTransitionScope.SlideDirection.Right,
                     animationSpec = tween(durationMillis = 350),
                 )
@@ -51,7 +51,7 @@ fun NavGraphBuilder.postsRoute(
         },
         exitTransition = {
             when (targetState.destination.route) {
-                HomeRoute.Posts::class.route -> slideOutOfContainer(
+                routeOf<HomeRoute.Posts>() -> slideOutOfContainer(
                     towards = AnimatedContentTransitionScope.SlideDirection.Right,
                     animationSpec = tween(durationMillis = 350),
                 )
@@ -59,32 +59,33 @@ fun NavGraphBuilder.postsRoute(
                 else -> null
             }
         },
-        content = { data ->
-            val bottomSheetNavigator = LocalBottomSheetNavigator.current
+    ) {
+        val bottomSheetNavigator = LocalBottomSheetNavigator.current
 
-            val isRouteFirstEntry = remember {
-                // 3 from list of null, MainRoute.Home, HomeRoute.Posts
-                mainNavController.currentBackStack.value.size == 3
-            }
+        val isRouteFirstEntry = remember {
+            // 3 from list of null, MainRoute.Home, HomeRoute.Posts
+            mainNavController.currentBackStack.value.size == 3
+        }
 
-            LaunchedEffect(key1 = data.tags) {
-                onCurrentTagsChange(data.tags)
-            }
+        val args = rememberNavArgsOf()
 
-            InterceptBackGestureForBottomSheetNavigator()
+        LaunchedEffect(key1 = args.tags) {
+            onCurrentTagsChange(args.tags)
+        }
 
-            PostsScreen(
-                isRouteFirstEntry = isRouteFirstEntry,
-                onNavigateBack = mainNavController::navigateUp,
-                onNavigateImage = lambdaOnNavigateImage,
-                onNavigateMore = { post ->
-                    bottomSheetNavigator.navigate {
-                        it.navigate(HomeRoute.PostMore(post))
-                    }
-                },
-            )
-        },
-    )
+        InterceptBackGestureForBottomSheetNavigator()
+
+        PostsScreen(
+            isRouteFirstEntry = isRouteFirstEntry,
+            onNavigateBack = mainNavController::navigateUp,
+            onNavigateImage = lambdaOnNavigateImage,
+            onNavigateMore = { post ->
+                bottomSheetNavigator.navigate {
+                    it.navigate(HomeRoute.PostMore(post))
+                }
+            },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterialApi::class)

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/more/PostMoreViewModel.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/more/PostMoreViewModel.kt
@@ -2,20 +2,20 @@ package com.uragiristereo.mikansei.feature.home.posts.more
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Profile
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.product.shared.postfavoritevote.PostFavoriteVote
 import com.uragiristereo.mikansei.core.product.shared.postfavoritevote.PostFavoriteVoteImpl
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.flow.StateFlow
 
 class PostMoreViewModel(
     savedStateHandle: SavedStateHandle,
     private val userRepository: UserRepository,
 ) : ViewModel(), PostFavoriteVote by PostFavoriteVoteImpl() {
-    override val post: Post = savedStateHandle.getData<HomeRoute.PostMore>()!!.post
+    override val post: Post = savedStateHandle.navArgsOf<HomeRoute.PostMore>()!!.post
 
     val activeUser: StateFlow<Profile>
         get() = userRepository.active

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/share/ShareViewModel.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/share/ShareViewModel.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.network.NetworkRepository
 import com.uragiristereo.mikansei.core.domain.usecase.ConvertFileSizeUseCase
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.launch
 
 class ShareViewModel(
@@ -20,7 +20,7 @@ class ShareViewModel(
     private val convertFileSizeUseCase: ConvertFileSizeUseCase,
     danbooruRepository: DanbooruRepository,
 ) : ViewModel() {
-    val navArgs = checkNotNull(savedStateHandle.getData<HomeRoute.Share>())
+    val navArgs = checkNotNull(savedStateHandle.navArgsOf<HomeRoute.Share>())
 
     val postLink = danbooruRepository.host.parsePostLink(navArgs.post.id)
 

--- a/feature/home/src/main/java/com/uragiristereo/mikansei/feature/home/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/uragiristereo/mikansei/feature/home/HomeNavigation.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.navigation
-import com.github.uragiristereo.safer.compose.navigation.core.route
 import com.uragiristereo.mikansei.core.ui.animation.holdIn
 import com.uragiristereo.mikansei.core.ui.animation.holdOut
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
@@ -15,6 +13,8 @@ import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.home.favorites.favoritesRoute
 import com.uragiristereo.mikansei.feature.home.more.core.moreRoute
 import com.uragiristereo.mikansei.feature.home.posts.core.postsRoute
+import com.uragiristereo.serializednavigationextension.navigation.compose.navigation
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 
 fun NavGraphBuilder.homeGraph(
     navController: NavHostController,
@@ -27,31 +27,31 @@ fun NavGraphBuilder.homeGraph(
         enterTransition = {
             when (initialState.destination.route) {
                 in HomeRoutesString -> fadeIn(animationSpec = tween(durationMillis = 300))
-                MainRoute.Search::class.route -> holdIn()
+                routeOf<MainRoute.Search>() -> holdIn()
                 else -> null
             }
         },
         exitTransition = {
             when (targetState.destination.route) {
                 in HomeRoutesString -> fadeOut(animationSpec = tween(durationMillis = 300))
-                MainRoute.Search::class.route -> holdOut()
-                MainRoute.Image::class.route -> holdOut()
+                routeOf<MainRoute.Search>() -> holdOut()
+                routeOf<MainRoute.Image>() -> holdOut()
                 else -> null
             }
         },
         popEnterTransition = {
             when (initialState.destination.route) {
                 in HomeRoutesString -> fadeIn(animationSpec = tween(durationMillis = 300))
-                MainRoute.Search::class.route -> fadeIn()
-                MainRoute.Image::class.route -> holdIn()
+                routeOf<MainRoute.Search>() -> fadeIn()
+                routeOf<MainRoute.Image>() -> holdIn()
                 else -> null
             }
         },
         popExitTransition = {
             when (targetState.destination.route) {
                 in HomeRoutesString -> fadeOut(animationSpec = tween(durationMillis = 300))
-                MainRoute.Search::class.route -> holdOut()
-                MainRoute.Image::class.route -> holdOut()
+                routeOf<MainRoute.Search>() -> holdOut()
+                routeOf<MainRoute.Image>() -> holdOut()
                 else -> null
             }
         }

--- a/feature/image/build.gradle
+++ b/feature/image/build.gradle
@@ -37,6 +37,5 @@ dependencies {
     implementation(libs.coil.gif)
     implementation(libs.touchimageview)
     implementation(libs.bundles.core)
-    implementation(libs.safer.navigation.compose)
     implementation(libs.bundles.media3)
 }

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/ImageScreen.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/ImageScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnDownload
 import com.uragiristereo.mikansei.core.ui.composable.SetSystemBarsColors
@@ -28,6 +27,7 @@ import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.feature.image.image.ImagePost
 import com.uragiristereo.mikansei.feature.image.more.MoreBottomSheet
 import com.uragiristereo.mikansei.feature.image.video.VideoPost
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/ViewerViewModel.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/ViewerViewModel.kt
@@ -5,13 +5,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 
 class ViewerViewModel(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-    val post = checkNotNull(savedStateHandle.getData<MainRoute.Image>()).post
+    val post = checkNotNull(savedStateHandle.navArgsOf<MainRoute.Image>()).post
 
     var areAppBarsVisible by mutableStateOf(true)
         private set

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/core/ImageNavigation.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/core/ImageNavigation.kt
@@ -4,15 +4,14 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.State
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
 import com.uragiristereo.mikansei.core.ui.animation.translateYFadeIn
 import com.uragiristereo.mikansei.core.ui.animation.translateYFadeOut
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.LocalBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.image.ImageScreen
-import timber.log.Timber
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 
 fun NavGraphBuilder.imageRoute(
     navController: NavHostController,
@@ -27,7 +26,6 @@ fun NavGraphBuilder.imageRoute(
             )
         },
         popExitTransition = {
-            Timber.d("navigatedBackByGesture ${navigatedBackByGesture.value}")
             when {
                 navigatedBackByGesture.value -> fadeOut()
                 else -> translateYFadeOut(

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/image/ImageViewModel.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/image/ImageViewModel.kt
@@ -7,19 +7,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Profile
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
 import com.uragiristereo.mikansei.core.model.preferences.user.DetailSizePreference
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.image.image.core.ImageLoadingState
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.flow.StateFlow
 
 class ImageViewModel(
     savedStateHandle: SavedStateHandle,
     private val userRepository: UserRepository,
 ) : ViewModel() {
-    val post = checkNotNull(savedStateHandle.getData<MainRoute.Image>()).post
+    val post = checkNotNull(savedStateHandle.navArgsOf<MainRoute.Image>()).post
 
     val activeUser: StateFlow<Profile>
         get() = userRepository.active

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheetViewModel.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheetViewModel.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Tag
 import com.uragiristereo.mikansei.core.domain.module.network.NetworkRepository
@@ -26,6 +25,7 @@ import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.product.shared.postfavoritevote.PostFavoriteVote
 import com.uragiristereo.mikansei.core.product.shared.postfavoritevote.PostFavoriteVoteImpl
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -37,7 +37,7 @@ class MoreBottomSheetViewModel(
     private val convertFileSizeUseCase: ConvertFileSizeUseCase,
 ) : ViewModel(),
     PostFavoriteVote by PostFavoriteVoteImpl() {
-    override var post = savedStateHandle.getData<MainRoute.Image>()!!.post
+    override var post = savedStateHandle.navArgsOf<MainRoute.Image>()!!.post
 
     var infoExpanded by mutableStateOf(false)
     var tagsExpanded by mutableStateOf(false)

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/video/VideoViewModel.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/video/VideoViewModel.kt
@@ -15,10 +15,10 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.network.NetworkRepository
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlin.math.floor
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -27,7 +27,7 @@ class VideoViewModel(
     private val networkRepository: NetworkRepository,
     private val applicationContext: Context,
 ) : ViewModel() {
-    val post = checkNotNull(savedStateHandle.getData<MainRoute.Image>()).post
+    val post = checkNotNull(savedStateHandle.navArgsOf<MainRoute.Image>()).post
 
     val exoPlayer = buildExoPlayer()
 

--- a/feature/search/build.gradle
+++ b/feature/search/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     implementation(libs.bundles.androidx.compose)
     implementation(libs.bundles.koin)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/SearchViewModel.kt
@@ -7,12 +7,12 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.uragiristereo.safer.compose.navigation.core.getData
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Tag
 import com.uragiristereo.mikansei.core.domain.usecase.GetTagsAutoCompleteUseCase
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.search.state.SearchWordIndex
+import com.uragiristereo.serializednavigationextension.runtime.navArgsOf
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -21,7 +21,7 @@ class SearchViewModel(
     savedStateHandle: SavedStateHandle,
     private val getTagsAutoCompleteUseCase: GetTagsAutoCompleteUseCase,
 ) : ViewModel() {
-    val tags = savedStateHandle.getData(MainRoute.Search()).tags
+    val tags = savedStateHandle.navArgsOf(MainRoute.Search()).tags
 
     var searchAllowed by mutableStateOf(true)
     var boldWord by mutableStateOf("")

--- a/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/core/SearchNavigation.kt
+++ b/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/core/SearchNavigation.kt
@@ -4,19 +4,19 @@ import androidx.compose.animation.fadeOut
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
 import com.uragiristereo.mikansei.core.ui.animation.holdIn
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoutesString
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.feature.search.SearchScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 
 fun NavGraphBuilder.searchRoute(
     navController: NavHostController,
 ) {
     composable(
-        route = MainRoute.Search(),
+        defaultValue = MainRoute.Search(),
         enterTransition = {
             holdIn()
         },
@@ -34,16 +34,15 @@ fun NavGraphBuilder.searchRoute(
                 in HomeRoutesString -> fadeOut()
                 else -> null
             }
-        },
-        content = {
-            SearchScreen(
-                onNavigateBack = navController::navigateUp,
-                onSearchSubmit = { tags ->
-                    navController.navigate(route = HomeRoute.Posts(tags)) {
-                        popUpTo(navController.graph.findStartDestination().id)
-                    }
-                },
-            )
         }
-    )
+    ) {
+        SearchScreen(
+            onNavigateBack = navController::navigateUp,
+            onSearchSubmit = { tags ->
+                navController.navigate(route = HomeRoute.Posts(tags)) {
+                    popUpTo(navController.graph.findStartDestination().id)
+                }
+            },
+        )
+    }
 }

--- a/feature/settings/build.gradle
+++ b/feature/settings/build.gradle
@@ -32,5 +32,4 @@ dependencies {
     implementation(libs.bundles.androidx.compose)
     implementation(libs.bundles.koin)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/settings/src/main/java/com/uragiristereo/mikansei/feature/settings/core/SettingsNavigation.kt
+++ b/feature/settings/src/main/java/com/uragiristereo/mikansei/feature/settings/core/SettingsNavigation.kt
@@ -2,11 +2,11 @@ package com.uragiristereo.mikansei.feature.settings.core
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.compose.navigation
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.core.ui.navigation.SettingsRoute
 import com.uragiristereo.mikansei.feature.settings.SettingsScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigation
 
 fun NavGraphBuilder.settingsGraph(
     navController: NavHostController,
@@ -15,13 +15,10 @@ fun NavGraphBuilder.settingsGraph(
         startDestination = SettingsRoute.Index::class,
         route = MainRoute.Settings::class,
     ) {
-        composable(
-            route = SettingsRoute.Index,
-            content = {
-                SettingsScreen(
-                    onNavigateBack = navController::navigateUp,
-                )
-            },
-        )
+        composable<SettingsRoute.Index> {
+            SettingsScreen(
+                onNavigateBack = navController::navigateUp,
+            )
+        }
     }
 }

--- a/feature/user/build.gradle
+++ b/feature/user/build.gradle
@@ -33,5 +33,4 @@ dependencies {
     implementation(libs.bundles.androidx.compose)
     implementation(libs.bundles.koin)
     implementation(libs.timber)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/user/login/build.gradle
+++ b/feature/user/login/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug)
     implementation(libs.bundles.core)
     implementation(libs.bundles.koin)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/user/login/src/main/java/com/uragiristereo/mikansei/feature/user/login/core/LoginNavigation.kt
+++ b/feature/user/login/src/main/java/com/uragiristereo/mikansei/feature/user/login/core/LoginNavigation.kt
@@ -2,16 +2,14 @@ package com.uragiristereo.mikansei.feature.user.login.core
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
 import com.uragiristereo.mikansei.core.ui.navigation.UserRoute
 import com.uragiristereo.mikansei.feature.user.login.LoginScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
 
 fun NavGraphBuilder.loginRoute(
     navController: NavHostController,
 ) {
-    composable(
-        route = UserRoute.Login,
-    ) {
+    composable<UserRoute.Login> {
         LoginScreen(
             onNavigateBack = navController::navigateUp,
         )

--- a/feature/user/manage/build.gradle
+++ b/feature/user/manage/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug)
     implementation(libs.bundles.core)
     implementation(libs.bundles.koin)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/user/manage/src/main/java/com/uragiristereo/mikansei/feature/user/manage/ManageUserScreen.kt
+++ b/feature/user/manage/src/main/java/com/uragiristereo/mikansei/feature/user/manage/ManageUserScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.github.uragiristereo.safer.compose.navigation.core.NavRoute
 import com.google.accompanist.insets.ui.Scaffold
 import com.uragiristereo.mikansei.core.product.component.ProductNavigationBarSpacer
 import com.uragiristereo.mikansei.core.product.component.ProductStatusBarSpacer
@@ -33,6 +32,7 @@ import com.uragiristereo.mikansei.core.ui.composable.SectionTitle
 import com.uragiristereo.mikansei.core.ui.extension.plus
 import com.uragiristereo.mikansei.core.ui.navigation.UserRoute
 import com.uragiristereo.mikansei.feature.user.manage.core.ProfileItem
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
 import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/feature/user/manage/src/main/java/com/uragiristereo/mikansei/feature/user/manage/core/ManageNavigation.kt
+++ b/feature/user/manage/src/main/java/com/uragiristereo/mikansei/feature/user/manage/core/ManageNavigation.kt
@@ -3,19 +3,17 @@ package com.uragiristereo.mikansei.feature.user.manage.core
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
-import com.github.uragiristereo.safer.compose.navigation.core.navigate
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.LocalBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.navigation.UserRoute
 import com.uragiristereo.mikansei.feature.user.manage.ManageUserScreen
 import com.uragiristereo.mikansei.feature.user.manage.switch_account.SwitchAccountContent
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 
 fun NavGraphBuilder.manageRoute(
     navController: NavHostController,
 ) {
-    composable(
-        route = UserRoute.Manage,
-    ) {
+    composable<UserRoute.Manage> {
         ManageUserScreen(
             onNavigate = navController::navigate,
             onNavigateBack = navController::navigateUp,
@@ -25,7 +23,7 @@ fun NavGraphBuilder.manageRoute(
 
 @OptIn(ExperimentalMaterialApi::class)
 fun NavGraphBuilder.manageBottomRoute(mainNavController: NavHostController) {
-    composable(UserRoute.Switch) {
+    composable<UserRoute.Switch> {
         val bottomSheetNavigator = LocalBottomSheetNavigator.current
 
         SwitchAccountContent(

--- a/feature/user/settings/build.gradle
+++ b/feature/user/settings/build.gradle
@@ -31,5 +31,4 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug)
     implementation(libs.bundles.core)
     implementation(libs.bundles.koin)
-    implementation(libs.safer.navigation.compose)
 }

--- a/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/core/UserSettingsNavigation.kt
+++ b/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/core/UserSettingsNavigation.kt
@@ -2,19 +2,16 @@ package com.uragiristereo.mikansei.feature.user.settings.core
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.composable
 import com.uragiristereo.mikansei.core.ui.navigation.UserRoute
 import com.uragiristereo.mikansei.feature.user.settings.UserSettingsScreen
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
 
 fun NavGraphBuilder.userSettingsRoute(
     navController: NavHostController,
 ) {
-    composable(
-        route = UserRoute.Settings,
-        content = {
-            UserSettingsScreen(
-                onNavigateBack = navController::navigateUp,
-            )
-        },
-    )
+    composable<UserRoute.Settings> {
+        UserSettingsScreen(
+            onNavigateBack = navController::navigateUp,
+        )
+    }
 }

--- a/feature/user/src/main/java/com/uragiristereo/mikansei/feature/user/UserNavigation.kt
+++ b/feature/user/src/main/java/com/uragiristereo/mikansei/feature/user/UserNavigation.kt
@@ -2,12 +2,12 @@ package com.uragiristereo.mikansei.feature.user
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import com.github.uragiristereo.safer.compose.navigation.compose.navigation
 import com.uragiristereo.mikansei.core.ui.navigation.MainRoute
 import com.uragiristereo.mikansei.core.ui.navigation.UserRoute
 import com.uragiristereo.mikansei.feature.user.login.core.loginRoute
 import com.uragiristereo.mikansei.feature.user.manage.core.manageRoute
 import com.uragiristereo.mikansei.feature.user.settings.core.userSettingsRoute
+import com.uragiristereo.serializednavigationextension.runtime.navigation
 
 fun NavGraphBuilder.userGraph(
     navController: NavHostController,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ koin = "3.5.0"
 coil = "2.4.0"
 okhttp = "5.0.0-alpha.11"
 retrofit = "2.9.0"
-safer-navigation-compose = "860e4afc2f"
+serialized-navigation-extension = "38fe773e9e"
 media3 = "1.2.0"
 gms = "4.4.0"
 firebase-bom = "32.7.0"
@@ -85,8 +85,9 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 # Timber Logger
 timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
 
-# Safer Navigation Compose
-safer-navigation-compose = { module = "com.github.uragiristereo.safer-navigation-compose:navigation-compose", version.ref = "safer-navigation-compose" }
+# Serialized Navigation Extension
+serialized-navigation-extension-compose = { module = "com.github.uragiristereo.serialized-navigation-extension:navigation-compose", version.ref = "serialized-navigation-extension" }
+serialized-navigation-extension-serializer-kotlinx = { module = "com.github.uragiristereo.serialized-navigation-extension:serializer-kotlinx", version.ref = "serialized-navigation-extension" }
 
 # AndroidX Media3
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }


### PR DESCRIPTION
As the title said.

The Safer Navigation Compose library is not being maintained anymore, replaced with the [rewrite version](https://github.com/uragiristereo/serialized-navigation-extension) with better API, [Kotlin Fragment DSL](https://developer.android.com/guide/navigation/design/kotlin-dsl) support, and custom serializer library.