### PR TITLE
Implement post border & show pending posts toggle

### DIFF
--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/post/PostMapper.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/post/PostMapper.kt
@@ -28,6 +28,12 @@ fun DanbooruPost.toPost(): Post {
             isPending -> Post.Status.PENDING
             else -> Post.Status.ACTIVE
         },
+        relationshipType = when {
+            hasChildren && parentId != null -> Post.RelationshipType.PARENT_CHILD
+            hasChildren -> Post.RelationshipType.PARENT
+            parentId != null -> Post.RelationshipType.CHILD
+            else -> Post.RelationshipType.NONE
+        },
         score = score,
         upScore = upScore,
         downScore = downScore,

--- a/core/database/schemas/com.uragiristereo.mikansei.core.database.MikanseiDatabase/1.json
+++ b/core/database/schemas/com.uragiristereo.mikansei.core.database.MikanseiDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "27892f68f99972967e623c710b27cada",
+    "identityHash": "37604f26c958b3e24253516dde572e59",
     "entities": [
       {
         "tableName": "sessions",
@@ -44,7 +44,7 @@
       },
       {
         "tableName": "users",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `api_key` TEXT NOT NULL DEFAULT '', `level` INTEGER NOT NULL, `safe_mode` INTEGER NOT NULL DEFAULT 1, `show_deleted_posts` INTEGER NOT NULL DEFAULT 0, `default_image_size` TEXT NOT NULL DEFAULT 'large', `blacklisted_tags` TEXT NOT NULL DEFAULT 'guro\nscat\nfurry', `is_active` INTEGER NOT NULL DEFAULT false, `posts_rating_filter` TEXT NOT NULL DEFAULT 'GENERAL_ONLY', `blur_questionable_posts` INTEGER NOT NULL DEFAULT 1, `blur_explicit_posts` INTEGER NOT NULL DEFAULT 1, `show_pending_posts` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `api_key` TEXT NOT NULL DEFAULT '', `level` INTEGER NOT NULL, `safe_mode` INTEGER NOT NULL DEFAULT 1, `show_deleted_posts` INTEGER NOT NULL DEFAULT 0, `default_image_size` TEXT NOT NULL DEFAULT 'large', `blacklisted_tags` TEXT NOT NULL DEFAULT 'guro\nscat\nfurry', `is_active` INTEGER NOT NULL DEFAULT false, `posts_rating_filter` TEXT NOT NULL DEFAULT 'GENERAL_ONLY', `blur_questionable_posts` INTEGER NOT NULL DEFAULT 1, `blur_explicit_posts` INTEGER NOT NULL DEFAULT 1, `show_pending_posts` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -131,8 +131,7 @@
             "fieldPath": "showPendingPosts",
             "columnName": "show_pending_posts",
             "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "0"
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -148,7 +147,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '27892f68f99972967e623c710b27cada')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '37604f26c958b3e24253516dde572e59')"
     ]
   }
 }

--- a/core/database/schemas/com.uragiristereo.mikansei.core.database.MikanseiDatabase/1.json
+++ b/core/database/schemas/com.uragiristereo.mikansei.core.database.MikanseiDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "7d0aa8bda3764fceedebca724f1bd3cb",
+    "identityHash": "27892f68f99972967e623c710b27cada",
     "entities": [
       {
         "tableName": "sessions",
@@ -44,7 +44,7 @@
       },
       {
         "tableName": "users",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `api_key` TEXT NOT NULL DEFAULT '', `level` INTEGER NOT NULL, `safe_mode` INTEGER NOT NULL DEFAULT 1, `show_deleted_posts` INTEGER NOT NULL DEFAULT 0, `default_image_size` TEXT NOT NULL DEFAULT 'large', `blacklisted_tags` TEXT NOT NULL DEFAULT 'guro\nscat\nfurry', `is_active` INTEGER NOT NULL DEFAULT false, `posts_rating_filter` TEXT NOT NULL DEFAULT 'GENERAL_ONLY', `blur_questionable_posts` INTEGER NOT NULL DEFAULT 1, `blur_explicit_posts` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `api_key` TEXT NOT NULL DEFAULT '', `level` INTEGER NOT NULL, `safe_mode` INTEGER NOT NULL DEFAULT 1, `show_deleted_posts` INTEGER NOT NULL DEFAULT 0, `default_image_size` TEXT NOT NULL DEFAULT 'large', `blacklisted_tags` TEXT NOT NULL DEFAULT 'guro\nscat\nfurry', `is_active` INTEGER NOT NULL DEFAULT false, `posts_rating_filter` TEXT NOT NULL DEFAULT 'GENERAL_ONLY', `blur_questionable_posts` INTEGER NOT NULL DEFAULT 1, `blur_explicit_posts` INTEGER NOT NULL DEFAULT 1, `show_pending_posts` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -126,6 +126,13 @@
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showPendingPosts",
+            "columnName": "show_pending_posts",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
           }
         ],
         "primaryKey": {
@@ -141,7 +148,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7d0aa8bda3764fceedebca724f1bd3cb')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '27892f68f99972967e623c710b27cada')"
     ]
   }
 }

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/DatabaseModule.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/DatabaseModule.kt
@@ -6,6 +6,7 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.uragiristereo.mikansei.core.database.user.UserRepositoryImpl
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
+import com.uragiristereo.mikansei.core.model.Environment
 import com.uragiristereo.mikansei.core.preferences.PreferencesRepository
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.bind
@@ -24,11 +25,17 @@ fun databaseModule() = module {
 
 private fun Scope.provideDatabase(context: Context): MikanseiDatabase {
     val preferencesRepository = get<PreferencesRepository>()
+    val environment = get<Environment>()
     val isTestMode = preferencesRepository.data.value.testMode
 
     val databaseName = when {
         isTestMode -> "mikansei-database-test.db"
         else -> "mikansei-database.db"
+    }
+
+    val showPendingPosts = when {
+        environment.safeMode -> "0"
+        else -> "1"
     }
 
     return Room
@@ -42,7 +49,7 @@ private fun Scope.provideDatabase(context: Context): MikanseiDatabase {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)
 
-                    db.execSQL("insert into users (id, name, level, is_active) values (0, 'Anonymous', 0, 1)")
+                    db.execSQL("insert into users (id, name, level, is_active, show_pending_posts) values (0, 'Anonymous', 0, 1, $showPendingPosts)")
                 }
             })
         .build()

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/user/UserMapper.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/user/UserMapper.kt
@@ -20,11 +20,11 @@ fun UserRow.toProfile(): Profile {
             },
         ),
         mikansei = Profile.MikanseiSettings(
-            // TODO: is prod account
             isActive = isActive,
             postsRatingFilter = postsRatingFilter,
             blurQuestionablePosts = blurQuestionablePosts,
             blurExplicitPosts = blurExplicitPosts,
+            showPendingPosts = showPendingPosts,
             nameAlias = getInitialChars(name),
         ),
     )
@@ -45,6 +45,7 @@ fun Profile.toUserRow(): UserRow {
         defaultImageSize = danbooru.defaultImageSize.getEnumForDanbooru(),
         blacklistedTags = danbooru.blacklistedTags.joinToString("\n"),
         postsRatingFilter = mikansei.postsRatingFilter,
+        showPendingPosts = mikansei.showPendingPosts,
         isActive = mikansei.isActive,
     )
 }

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/user/UserRepositoryImpl.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/user/UserRepositoryImpl.kt
@@ -41,5 +41,9 @@ class UserRepositoryImpl(
 
     override suspend fun update(user: Profile) = userDao.update(user.toUserRow())
 
+    override suspend fun update(transformation: (Profile) -> Profile) {
+        userDao.update(transformation(active.value).toUserRow())
+    }
+
     override suspend fun delete(user: Profile) = userDao.delete(user.toUserRow())
 }

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/user/UserRow.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/user/UserRow.kt
@@ -42,4 +42,7 @@ data class UserRow(
 
     @ColumnInfo(name = "blur_explicit_posts", defaultValue = "1")
     val blurExplicitPosts: Boolean = true,
+
+    @ColumnInfo(name = "show_pending_posts")
+    val showPendingPosts: Boolean,
 )

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/danbooru/entity/Profile.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/danbooru/entity/Profile.kt
@@ -40,11 +40,11 @@ data class Profile(
     )
 
     data class MikanseiSettings(
-        val isProdAccount: Boolean = true,
         val isActive: Boolean = false,
         val postsRatingFilter: RatingPreference = RatingPreference.GENERAL_ONLY,
         val blurQuestionablePosts: Boolean = true,
         val blurExplicitPosts: Boolean = true,
+        val showPendingPosts: Boolean = false,
         val nameAlias: String = "",
     )
 

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/database/UserRepository.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/database/UserRepository.kt
@@ -19,5 +19,7 @@ interface UserRepository {
 
     suspend fun update(user: Profile)
 
+    suspend fun update(transformation: (Profile) -> Profile)
+
     suspend fun delete(user: Profile)
 }

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetPostsUseCase.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetPostsUseCase.kt
@@ -35,6 +35,11 @@ class GetPostsUseCase(
                     else -> listOf(false)
                 }
 
+                val showPendingPosts = when {
+                    profile.mikansei.showPendingPosts || tags.contains("status:any") || tags.contains("status:pending") -> listOf(false, true)
+                    else -> listOf(false)
+                }
+
                 posts = posts.filter { post ->
                     !profile.danbooru.blacklistedTags.any { tags ->
                         tags.split(' ')
@@ -65,6 +70,7 @@ class GetPostsUseCase(
                             && post.rating !in ratingFilters
                             && post.status != Post.Status.BANNED
                             && (post.status == Post.Status.DELETED) in showDeletedPosts
+                            && (post.status == Post.Status.PENDING) in showPendingPosts
                 }
 
                 if (canLoadMore && posts.isEmpty()) {

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/PerformLoginUseCase.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/PerformLoginUseCase.kt
@@ -2,11 +2,13 @@ package com.uragiristereo.mikansei.core.domain.usecase
 
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
+import com.uragiristereo.mikansei.core.model.Environment
 import com.uragiristereo.mikansei.core.model.result.Result
 
 class PerformLoginUseCase(
     private val danbooruRepository: DanbooruRepository,
     private val userRepository: UserRepository,
+    private val environment: Environment,
 ) {
     suspend operator fun invoke(
         name: String,
@@ -22,7 +24,10 @@ class PerformLoginUseCase(
                     userExists -> Result.Failed("User is already logged in.")
                     else -> {
                         userRepository.add(
-                            user = profile.copy(apiKey = apiKey)
+                            user = profile.copy(
+                                apiKey = apiKey,
+                                mikansei = profile.mikansei.copy(showPendingPosts = !environment.safeMode),
+                            )
                         )
 
                         userRepository.switchActive(profile.id)

--- a/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/Post.kt
+++ b/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/Post.kt
@@ -16,6 +16,7 @@ data class Post(
     val source: String?,
     val rating: Rating,
     val status: Status,
+    val relationshipType: RelationshipType,
 
     val score: Int,
     val upScore: Int,
@@ -57,5 +58,12 @@ data class Post(
         PENDING,
         DELETED,
         BANNED,
+    }
+
+    enum class RelationshipType {
+        NONE,
+        PARENT,
+        CHILD,
+        PARENT_CHILD,
     }
 }

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -104,6 +104,11 @@
     <string name="image_rating_sensitive">Sensitive</string>
     <string name="image_rating_questionable">Questionable</string>
     <string name="image_rating_explicit">Explicit</string>
+    <string name="image_status">Status</string>
+    <string name="image_status_active">Active</string>
+    <string name="image_status_pending">Pending</string>
+    <string name="image_status_deleted">Deleted</string>
+    <string name="image_status__banned">Banned</string>
     <string name="image_uploaded_by">Uploaded by</string>
     <string name="image_compressed">Compressed (sample)</string>
     <string name="image_original">Full size (original)</string>

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/grid/PostBorder.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/grid/PostBorder.kt
@@ -1,0 +1,196 @@
+package com.uragiristereo.mikansei.feature.home.posts.grid
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.GenericShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.uragiristereo.mikansei.core.model.danbooru.Post
+import com.uragiristereo.mikansei.core.product.theme.MikanseiTheme
+
+@Composable
+fun PostBorder(
+    status: Post.Status,
+    relationshipType: Post.RelationshipType,
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        val colors = generateColors(status, relationshipType)
+        val isPostHasBorder = colors.bottomRight != null && colors.top != null && colors.left != null
+
+        Box(
+            modifier = when {
+                isPostHasBorder -> Modifier.padding(all = BorderWidth)
+                else -> Modifier
+            },
+            content = content,
+        )
+
+        RoundedCornerBorder(
+            color = colors.bottomRight ?: Color.Transparent,
+            clipShape = BottomRightBorderShape,
+        )
+
+        RoundedCornerBorder(
+            color = colors.left ?: Color.Transparent,
+            clipShape = LeftBorderShape,
+        )
+
+        RoundedCornerBorder(
+            color = colors.top ?: Color.Transparent,
+            clipShape = TopBorderShape,
+        )
+    }
+}
+
+
+@Composable
+private fun RoundedCornerBorder(
+    color: Color,
+    clipShape: Shape,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clip(clipShape)
+            .border(
+                width = BorderWidth,
+                color = color,
+                shape = RoundedCornerShape(8.dp),
+            ),
+    )
+}
+
+@Composable
+private fun generateColors(
+    status: Post.Status,
+    relationshipType: Post.RelationshipType,
+): BorderColor {
+    return when (relationshipType) {
+        Post.RelationshipType.PARENT_CHILD -> when (status) {
+            Post.Status.PENDING -> BorderColor(PendingColor, ParentColor, ChildColor)
+            Post.Status.DELETED, Post.Status.BANNED -> BorderColor(DeletedBannedColor, ParentColor, ChildColor)
+            Post.Status.ACTIVE -> BorderColor(ChildColor, ParentColor, ParentColor)
+        }
+
+        Post.RelationshipType.PARENT -> when (status) {
+            Post.Status.PENDING -> BorderColor(PendingColor, ParentColor, ParentColor)
+            Post.Status.DELETED, Post.Status.BANNED -> BorderColor(DeletedBannedColor, ParentColor, ParentColor)
+            Post.Status.ACTIVE -> BorderColor(ParentColor, ParentColor, ParentColor)
+        }
+
+        Post.RelationshipType.CHILD -> when (status) {
+            Post.Status.PENDING -> BorderColor(PendingColor, ChildColor, ChildColor)
+            Post.Status.DELETED, Post.Status.BANNED -> BorderColor(DeletedBannedColor, ChildColor, ChildColor)
+            Post.Status.ACTIVE -> BorderColor(ChildColor, ChildColor, ChildColor)
+        }
+
+        Post.RelationshipType.NONE -> when (status) {
+            Post.Status.PENDING -> BorderColor(PendingColor, PendingColor, PendingColor)
+            Post.Status.DELETED, Post.Status.BANNED -> BorderColor(DeletedBannedColor, DeletedBannedColor, DeletedBannedColor)
+            Post.Status.ACTIVE -> BorderColor(null, null, null)
+        }
+    }
+}
+
+data class BorderColor(
+    val bottomRight: Color?,
+    val top: Color?,
+    val left: Color?,
+)
+
+private val BorderWidth = 2.dp
+private val PendingColor = Color(0xFF0095DD)
+private val DeletedBannedColor = Color(0xFFABABBC)
+private val ParentColor = Color(0xFF30B443)
+private val ChildColor = Color(0xFFFD9200)
+
+private val BottomRightBorderShape = GenericShape { size, _ ->
+    moveTo(size.width, 0f)
+    lineTo(0f, size.height)
+    lineTo(size.width, size.height)
+}
+
+private val TopBorderShape = GenericShape { size, _ ->
+    moveTo(size.width, 0f)
+    lineTo(size.width / 2f, size.height / 2f)
+    lineTo(0f, 0f)
+}
+
+private val LeftBorderShape = GenericShape { size, _ ->
+    moveTo(0f, 0f)
+    lineTo(size.width / 2f, size.height / 2f)
+    lineTo(0f, size.height)
+}
+
+@Preview
+@Composable
+private fun PostBorderPreview() {
+    val modifierSize = Modifier.size(
+        width = 40.dp,
+        height = 30.dp,
+    )
+
+    MikanseiTheme {
+        Surface {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                PostBorder(
+                    status = Post.Status.DELETED,
+                    relationshipType = Post.RelationshipType.NONE,
+                    modifier = modifierSize,
+                    content = {},
+                )
+                PostBorder(
+                    status = Post.Status.DELETED,
+                    relationshipType = Post.RelationshipType.PARENT,
+                    modifier = modifierSize,
+                    content = {},
+                )
+                PostBorder(
+                    status = Post.Status.PENDING,
+                    relationshipType = Post.RelationshipType.CHILD,
+                    modifier = modifierSize,
+                    content = {},
+                )
+
+                PostBorder(
+                    status = Post.Status.ACTIVE,
+                    relationshipType = Post.RelationshipType.PARENT_CHILD,
+                    modifier = modifierSize,
+                    content = {},
+                )
+
+                PostBorder(
+                    status = Post.Status.PENDING,
+                    relationshipType = Post.RelationshipType.PARENT_CHILD,
+                    modifier = modifierSize,
+                    content = {},
+                )
+
+                PostBorder(
+                    status = Post.Status.PENDING,
+                    relationshipType = Post.RelationshipType.NONE,
+                    modifier = modifierSize,
+                    content = {},
+                )
+            }
+        }
+    }
+}

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/grid/PostItem.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/grid/PostItem.kt
@@ -3,7 +3,6 @@ package com.uragiristereo.mikansei.feature.home.posts.grid
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -31,7 +30,9 @@ internal fun PostItem(
 ) {
     val context = LocalContext.current
 
-    Box(
+    PostBorder(
+        status = post.status,
+        relationshipType = post.relationshipType,
         modifier = modifier
             .aspectRatio(post.aspectRatio)
             .clip(RoundedCornerShape(size = 8.dp))

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheet.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -34,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.uragiristereo.mikansei.core.model.danbooru.Post
+import com.uragiristereo.mikansei.core.model.preferences.user.RatingPreference
 import com.uragiristereo.mikansei.core.product.component.ProductModalBottomSheet
 import com.uragiristereo.mikansei.core.resources.R
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnDownload
@@ -73,11 +75,16 @@ internal fun MoreBottomSheet(
     val windowSizeHorizontal = LocalWindowSizeHorizontal.current
 
     val tagsCount = remember(post) { post.tags.size }
+    val activeUser by viewModel.activeUser.collectAsState()
 
     val closeButtonVisible by remember {
         derivedStateOf {
             viewModel.tagsExpanded && windowSizeHorizontal == WindowSize.COMPACT && viewModel.tags.isNotEmpty()
         }
+    }
+
+    val isInSafeMode = remember(activeUser) {
+        activeUser.danbooru.safeMode || activeUser.mikansei.postsRatingFilter == RatingPreference.GENERAL_ONLY
     }
 
     LaunchedEffect(key1 = sheetState.currentValue) {
@@ -229,6 +236,7 @@ internal fun MoreBottomSheet(
                             originalImageFileSizeStr = viewModel.originalImageFileSizeStr,
                             expanded = viewModel.infoExpanded,
                             uploaderName = viewModel.uploaderName,
+                            shouldShowRating = !isInSafeMode,
                             onMoreClick = remember {
                                 {
                                     viewModel.infoExpanded = true

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheetViewModel.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheetViewModel.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Tag
+import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
 import com.uragiristereo.mikansei.core.domain.module.network.NetworkRepository
 import com.uragiristereo.mikansei.core.domain.usecase.ConvertFileSizeUseCase
 import com.uragiristereo.mikansei.core.domain.usecase.GetTagsUseCase
@@ -33,6 +34,7 @@ class MoreBottomSheetViewModel(
     savedStateHandle: SavedStateHandle,
     private val danbooruRepository: DanbooruRepository,
     private val networkRepository: NetworkRepository,
+    private val userRepository: UserRepository,
     private val getTagsUseCase: GetTagsUseCase,
     private val convertFileSizeUseCase: ConvertFileSizeUseCase,
 ) : ViewModel(),
@@ -56,6 +58,7 @@ class MoreBottomSheetViewModel(
         private set
 
     val postLink = danbooruRepository.host.parsePostLink(post.id)
+    val activeUser = userRepository.active
 
     init {
         getUploaderName()

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/info/MoreInfoColumn.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/info/MoreInfoColumn.kt
@@ -1,7 +1,6 @@
 package com.uragiristereo.mikansei.feature.image.more.info
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -17,7 +16,6 @@ import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.model.danbooru.Rating
 import com.uragiristereo.mikansei.core.resources.R
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun MoreInfoColumn(
     post: Post,
@@ -25,6 +23,7 @@ internal fun MoreInfoColumn(
     originalImageFileSizeStr: String,
     expanded: Boolean,
     uploaderName: String,
+    shouldShowRating: Boolean,
     onMoreClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -36,15 +35,32 @@ internal fun MoreInfoColumn(
         ),
     ) {
         MoreInfo(
-            title = stringResource(id = R.string.image_rating),
-            subtitle = when (post.rating) {
-                Rating.GENERAL -> stringResource(id = R.string.image_rating_general)
-                Rating.SENSITIVE -> stringResource(id = R.string.image_rating_sensitive)
-                Rating.QUESTIONABLE -> stringResource(id = R.string.image_rating_questionable)
-                Rating.EXPLICIT -> stringResource(id = R.string.image_rating_explicit)
-            },
+            title = stringResource(id = R.string.image_status),
+            subtitle = stringResource(
+                id = when (post.status) {
+                    Post.Status.ACTIVE -> R.string.image_status_active
+                    Post.Status.PENDING -> R.string.image_status_pending
+                    Post.Status.DELETED -> R.string.image_status_deleted
+                    Post.Status.BANNED -> R.string.image_status__banned
+                },
+            ),
             modifier = Modifier.padding(bottom = 8.dp),
         )
+
+        if (shouldShowRating) {
+            MoreInfo(
+                title = stringResource(id = R.string.image_rating),
+                subtitle = stringResource(
+                    id = when (post.rating) {
+                        Rating.GENERAL -> R.string.image_rating_general
+                        Rating.SENSITIVE -> R.string.image_rating_sensitive
+                        Rating.QUESTIONABLE -> R.string.image_rating_questionable
+                        Rating.EXPLICIT -> R.string.image_rating_explicit
+                    },
+                ),
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
 
         MoreInfo(
             title = stringResource(id = R.string.image_uploaded_by),
@@ -93,6 +109,5 @@ internal fun MoreInfoColumn(
                 }
             },
         )
-
     }
 }

--- a/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/UserSettingsScreen.kt
+++ b/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/UserSettingsScreen.kt
@@ -24,6 +24,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.uragiristereo.mikansei.core.model.preferences.user.DetailSizePreference
 import com.uragiristereo.mikansei.core.product.component.ProductNavigationBarSpacer
@@ -98,6 +102,14 @@ internal fun UserSettingsScreen(
                 contentPadding = innerPadding,
                 modifier = Modifier.fillMaxSize(),
             ) {
+                item {
+                    SettingTip(text = "(*) indicates a Mikansei feature and won't be synced with Danbooru.")
+                }
+
+                item {
+                    Divider()
+                }
+
                 if (!viewModel.safeModeEnvironment) {
                     item {
                         SwitchPreference(
@@ -118,8 +130,7 @@ internal fun UserSettingsScreen(
                             if (state) {
                                 RegularPreference(
                                     title = "Posts rating listing filters (*)",
-                                    subtitle = viewModel.ratingFilters.selectedItem?.getTitleString()
-                                        .orEmpty(),
+                                    subtitle = viewModel.ratingFilters.selectedItem?.getTitleString().orEmpty(),
                                     onClick = {
                                         scope.launch {
                                             bottomSheetPreferenceState.navigate(data = viewModel.ratingFilters)
@@ -135,7 +146,15 @@ internal fun UserSettingsScreen(
                 item {
                     SwitchPreference(
                         title = "Show deleted posts",
-                        subtitle = null,
+                        subtitle = buildAnnotatedString {
+                            append(text = "Show posts that are tagged with ")
+
+                            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append(text = "status:deleted")
+                            }
+
+                            append(text = " or marked with grey border.\n")
+                        },
                         selected = activeUser.danbooru.showDeletedPosts,
                         onSelectedChange = viewModel::onShowDeletedPostsChange,
                         icon = null,
@@ -157,11 +176,28 @@ internal fun UserSettingsScreen(
                 }
 
                 item {
-                    Divider()
-                }
+                    SwitchPreference(
+                        title = "Show pending posts (*)",
+                        subtitle = buildAnnotatedString {
+                            append(text = "Show posts that are tagged with ")
 
-                item {
-                    SettingTip(text = "(*) indicates a Mikansei feature and won't be synced with Danbooru.")
+                            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append(text = "status:pending")
+                            }
+
+                            append(text = " or marked with blue border.\n")
+
+                            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append(text = "Note:")
+                            }
+
+                            append(text = " pending posts sometimes got tagged incorrectly.")
+                        },
+                        selected = activeUser.mikansei.showPendingPosts,
+                        onSelectedChange = viewModel::onShowPendingPostsChange,
+                        icon = null,
+                        enabled = shouldEnableSettings,
+                    )
                 }
             }
 

--- a/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/UserSettingsScreen.kt
+++ b/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/UserSettingsScreen.kt
@@ -153,7 +153,7 @@ internal fun UserSettingsScreen(
                                 append(text = "status:deleted")
                             }
 
-                            append(text = " or marked with grey border.\n")
+                            append(text = " or marked with grey border.")
                         },
                         selected = activeUser.danbooru.showDeletedPosts,
                         onSelectedChange = viewModel::onShowDeletedPostsChange,

--- a/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/UserSettingsViewModel.kt
+++ b/feature/user/settings/src/main/java/com/uragiristereo/mikansei/feature/user/settings/UserSettingsViewModel.kt
@@ -115,15 +115,25 @@ class UserSettingsViewModel(
         updateSettings(data = ProfileSettingsField(defaultImageSize = value))
     }
 
+    fun onShowPendingPostsChange(value: Boolean) {
+        viewModelScope.launch {
+            userRepository.update { profile ->
+                profile.copy(
+                    mikansei = profile.mikansei.copy(showPendingPosts = value),
+                )
+            }
+        }
+    }
+
     fun setBottomSheetPreferenceState(preference: Preference) {
         when (preference) {
             is RatingPreference -> {
                 viewModelScope.launch {
-                    userRepository.update(
-                        user = activeUser.value.copy(
-                            mikansei = activeUser.value.mikansei.copy(postsRatingFilter = preference),
-                        ),
-                    )
+                    userRepository.update { profile ->
+                        profile.copy(
+                            mikansei = profile.mikansei.copy(postsRatingFilter = preference),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
To catch up with the Danbooru site feature, I added border to post list items to indicate what status & relationship the posts have, the colors are exactly the same with the Danbooru site.

Furthermore, I added a Mikansei-specific toggle to show pending posts on the Account settings page, the default value depends on the current app environment. For the regular environment, the default value is true, and false for the safe environment.

### Summary of changes:
- Added relationship type field to Post
- Added post status info on Image More Bottom Sheet
- Implemented the conditional post border
- Added show pending post toggle

### Screenshots:
![post-border](https://github.com/uragiristereo/Mikansei/assets/52477630/67ea970d-9aae-4618-8fb6-fff356679581)

