### PR TITLE
Refactor date & time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,10 @@ android {
         kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
     }
 
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
+
     packagingOptions {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -114,4 +118,5 @@ dependencies {
     playImplementation(platform(libs.firebase.bom))
     playImplementation(libs.firebase.analytics)
     playImplementation(libs.firebase.crashlytics)
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/core/danbooru/build.gradle
+++ b/core/danbooru/build.gradle
@@ -6,6 +6,10 @@ plugins {
 
 android {
     namespace "com.uragiristereo.mikansei.core.danbooru"
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
 }
 
 kotlin {
@@ -22,4 +26,5 @@ dependencies {
     implementation(libs.bundles.core)
     implementation(libs.bundles.retrofit)
     implementation(libs.kotlinx.serialization.json)
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/favorite/DanbooruFavoriteGroup.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/favorite/DanbooruFavoriteGroup.kt
@@ -4,7 +4,7 @@ package com.uragiristereo.mikansei.core.danbooru.model.favorite
 import com.uragiristereo.mikansei.core.model.danbooru.DanbooruDateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Serializable
 data class DanbooruFavoriteGroup(
@@ -22,11 +22,11 @@ data class DanbooruFavoriteGroup(
 
     @SerialName("created_at")
     @Serializable(DanbooruDateSerializer::class)
-    val createdAt: Date,
+    val createdAt: OffsetDateTime,
 
     @SerialName("updated_at")
     @Serializable(DanbooruDateSerializer::class)
-    val updatedAt: Date,
+    val updatedAt: OffsetDateTime,
 
     @SerialName("is_public")
     val isPublic: Boolean,

--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/post/DanbooruPost.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/post/DanbooruPost.kt
@@ -4,7 +4,7 @@ package com.uragiristereo.mikansei.core.danbooru.model.post
 import com.uragiristereo.mikansei.core.model.danbooru.DanbooruDateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Serializable
 data class DanbooruPost(
@@ -13,7 +13,7 @@ data class DanbooruPost(
 
     @SerialName("created_at")
     @Serializable(with = DanbooruDateSerializer::class)
-    val createdAt: Date,
+    val createdAt: OffsetDateTime,
 
     @SerialName("uploader_id")
     val uploaderId: Int,
@@ -95,7 +95,7 @@ data class DanbooruPost(
 
     @SerialName("updated_at")
     @Serializable(with = DanbooruDateSerializer::class)
-    val updatedAt: Date,
+    val updatedAt: OffsetDateTime,
 
     @SerialName("is_banned")
     val isBanned: Boolean,

--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/post/vote/DanbooruPostVote.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/post/vote/DanbooruPostVote.kt
@@ -3,7 +3,7 @@ package com.uragiristereo.mikansei.core.danbooru.model.post.vote
 import com.uragiristereo.mikansei.core.model.danbooru.DanbooruDateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Serializable
 data class DanbooruPostVote(
@@ -18,11 +18,11 @@ data class DanbooruPostVote(
 
     @SerialName("created_at")
     @Serializable(DanbooruDateSerializer::class)
-    val createdAt: Date,
+    val createdAt: OffsetDateTime,
 
     @SerialName("updated_at")
     @Serializable(DanbooruDateSerializer::class)
-    val updatedAt: Date,
+    val updatedAt: OffsetDateTime,
 
     @SerialName("score")
     val score: Int,

--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/profile/DanbooruProfile.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/profile/DanbooruProfile.kt
@@ -3,13 +3,13 @@ package com.uragiristereo.mikansei.core.danbooru.model.profile
 import com.uragiristereo.mikansei.core.model.danbooru.DanbooruDateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Serializable
 data class DanbooruProfile(
     @SerialName("last_logged_in_at")
     @Serializable(DanbooruDateSerializer::class)
-    val lastLoggedInAt: Date,
+    val lastLoggedInAt: OffsetDateTime,
 
     @SerialName("id")
     val id: Int,
@@ -26,19 +26,19 @@ data class DanbooruProfile(
     @SerialName("created_at")
 
     @Serializable(DanbooruDateSerializer::class)
-    val createdAt: Date,
+    val createdAt: OffsetDateTime,
 
     @SerialName("last_forum_read_at")
 
     @Serializable(DanbooruDateSerializer::class)
-    val lastForumReadAt: Date,
+    val lastForumReadAt: OffsetDateTime,
 
     @SerialName("comment_threshold")
     val commentThreshold: Int,
 
     @SerialName("updated_at")
     @Serializable(DanbooruDateSerializer::class)
-    val updatedAt: Date,
+    val updatedAt: OffsetDateTime,
 
     @SerialName("default_image_size")
     val defaultImageSize: String,

--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/saved_search/DanbooruSavedSearch.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/model/saved_search/DanbooruSavedSearch.kt
@@ -3,7 +3,7 @@ package com.uragiristereo.mikansei.core.danbooru.model.saved_search
 import com.uragiristereo.mikansei.core.model.danbooru.DanbooruDateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Serializable
 data class DanbooruSavedSearch(
@@ -18,11 +18,11 @@ data class DanbooruSavedSearch(
 
     @SerialName("created_at")
     @Serializable(DanbooruDateSerializer::class)
-    val createdAt: Date,
+    val createdAt: OffsetDateTime,
 
     @SerialName("updated_at")
     @Serializable(DanbooruDateSerializer::class)
-    val updatedAt: Date,
+    val updatedAt: OffsetDateTime,
 
     @SerialName("labels")
     val labels: List<String>,

--- a/core/database/build.gradle
+++ b/core/database/build.gradle
@@ -7,6 +7,10 @@ plugins {
 android {
     namespace "com.uragiristereo.mikansei.core.database"
 
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
+
     ksp {
         arg("room.schemaLocation", "$projectDir/schemas")
     }
@@ -26,4 +30,5 @@ dependencies {
     implementation(libs.bundles.room)
     ksp(libs.room.compiler)
     implementation(libs.kotlinx.serialization.json)
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/DatabaseConverters.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/DatabaseConverters.kt
@@ -4,7 +4,9 @@ import androidx.room.TypeConverter
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.util.Date
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class DatabaseConverters {
     private val json = Json {
@@ -12,13 +14,15 @@ class DatabaseConverters {
     }
 
     @TypeConverter
-    fun timestampToDate(value: Long?): Date? {
-        return value?.let { Date(it) }
+    fun timestampToOffsetDateTime(value: Long?): OffsetDateTime? {
+        return value?.let {
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(it), ZoneOffset.UTC)
+        }
     }
 
     @TypeConverter
-    fun dateToTimestamp(date: Date?): Long? {
-        return date?.time
+    fun offsetDateTimeToTimestamp(date: OffsetDateTime?): Long? {
+        return date?.toInstant()?.toEpochMilli()
     }
 
     @TypeConverter

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/post/PostDao.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/post/PostDao.kt
@@ -6,7 +6,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import kotlinx.coroutines.flow.Flow
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Dao
 interface PostDao {
@@ -25,7 +25,7 @@ interface PostDao {
             where post_id = :postId
         """
     )
-    suspend fun update(postId: Int, post: Post, updatedAt: Date = Date())
+    suspend fun update(postId: Int, post: Post, updatedAt: OffsetDateTime = OffsetDateTime.now())
 
     @Transaction
     suspend fun update(posts: List<Post>) {
@@ -51,7 +51,7 @@ interface PostDao {
     suspend fun updateUploaderName(
         postId: Int,
         uploaderName: String,
-        updatedAt: Date = Date(),
+        updatedAt: OffsetDateTime = OffsetDateTime.now(),
     )
 
     @Query("delete from posts")

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/post/PostRow.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/post/PostRow.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.uragiristereo.mikansei.core.model.danbooru.Post
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Entity(tableName = "posts")
 data class PostRow(
@@ -19,5 +19,5 @@ data class PostRow(
     val uploaderName: String? = null,
 
     @ColumnInfo(name = "updated_at")
-    val updatedAt: Date = Date(),
+    val updatedAt: OffsetDateTime = OffsetDateTime.now(),
 )

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/search_history/SearchHistoryRow.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/search_history/SearchHistoryRow.kt
@@ -2,11 +2,11 @@ package com.uragiristereo.mikansei.core.database.search_history
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Entity(tableName = "search_history")
 data class SearchHistoryRow(
     @PrimaryKey val uuid: String,
     val tags: String,
-    val date: Date,
+    val date: OffsetDateTime,
 )

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/tag_category/TagCategoryRow.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/tag_category/TagCategoryRow.kt
@@ -3,7 +3,7 @@ package com.uragiristereo.mikansei.core.database.tag_category
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Entity(tableName = "tag_categories")
 data class TagCategoryRow(
@@ -15,5 +15,5 @@ data class TagCategoryRow(
     val category: String,
 
     @ColumnInfo(name = "updated_at")
-    val updatedAt: Date = Date(),
+    val updatedAt: OffsetDateTime = OffsetDateTime.now(),
 )

--- a/core/model/build.gradle
+++ b/core/model/build.gradle
@@ -15,6 +15,10 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
     }
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
 }
 
 kotlin {
@@ -28,4 +32,5 @@ dependencies {
     implementation(libs.compose)
     implementation(libs.bundles.retrofit)
     implementation(libs.kotlinx.serialization.json)
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/DanbooruDateSerializer.kt
+++ b/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/DanbooruDateSerializer.kt
@@ -6,21 +6,21 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 
-object DanbooruDateSerializer : KSerializer<Date> {
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ", Locale.US)
+object DanbooruDateSerializer : KSerializer<OffsetDateTime> {
+    private val dateFormat = DateTimeFormatter.ISO_DATE_TIME
 
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(serialName = "Date", kind = PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, value: Date) {
+    override fun serialize(encoder: Encoder, value: OffsetDateTime) {
         encoder.encodeString(dateFormat.format(value))
     }
 
-    override fun deserialize(decoder: Decoder): Date {
+    override fun deserialize(decoder: Decoder): OffsetDateTime {
         val string = decoder.decodeString()
 
-        return dateFormat.parse(string) ?: Date()
+        return OffsetDateTime.from(dateFormat.parse(string))
     }
 }

--- a/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/Post.kt
+++ b/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/Post.kt
@@ -2,7 +2,7 @@ package com.uragiristereo.mikansei.core.model.danbooru
 
 import androidx.compose.runtime.Stable
 import kotlinx.serialization.Serializable
-import java.util.Date
+import java.time.OffsetDateTime
 
 @Stable
 @Serializable
@@ -10,7 +10,7 @@ data class Post(
     val id: Int,
 
     @Serializable(DanbooruDateSerializer::class)
-    val createdAt: Date,
+    val createdAt: OffsetDateTime,
 
     val uploaderId: Int,
     val source: String?,

--- a/feature/image/build.gradle
+++ b/feature/image/build.gradle
@@ -13,6 +13,10 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
     }
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
 }
 
 kotlin {
@@ -38,4 +42,5 @@ dependencies {
     implementation(libs.touchimageview)
     implementation(libs.bundles.core)
     implementation(libs.bundles.media3)
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheet.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheet.kt
@@ -53,7 +53,9 @@ import com.uragiristereo.mikansei.feature.image.more.tags.MoreTagsRow
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
-import java.text.DateFormat
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
@@ -195,10 +197,17 @@ internal fun MoreBottomSheet(
                     }
 
                     item {
-                        val df = remember { DateFormat.getDateTimeInstance() }
+                        val formatted = remember(post.createdAt) {
+                            val zonedDateTime = post.createdAt
+                                .atZoneSameInstant(ZoneId.systemDefault())
+
+                            DateTimeFormatter
+                                .ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.MEDIUM)
+                                .format(zonedDateTime)
+                        }
 
                         Text(
-                            text = df.format(post.createdAt),
+                            text = formatted,
                             fontSize = 16.sp,
                             fontWeight = FontWeight.Medium,
                             modifier = Modifier

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ gms = "4.4.1"
 firebase-bom = "32.8.0"
 firebase-crashlytics = "2.9.9"
 junit = "4.13.2"
+desugar-jdk-libs = "2.0.4"
 
 
 [plugins]
@@ -104,6 +105,9 @@ firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx"
 #Testing
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+
+# Desugaring
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 
 
 [bundles]


### PR DESCRIPTION
After PR #25, I saw random crashes when browsing, related to date & time. I think it's because the old `java.util.Date` is not thread safe and overall have a troublesome API to use. So I decided to use `java.time` API from Java 8. To be able to use it while having `minSdk 21`, I need to use [core library desugaring](https://developer.android.com/studio/write/java8-support). Tests were performed and I didn't experience crashes again.

### Result
![Screenshot_20240629_112619](https://github.com/uragiristereo/Mikansei/assets/52477630/3826f9a0-3019-4bc6-90f0-6fb1fa22638c)

The displayed date is accurate with the date in the Danbooru site

![image](https://github.com/uragiristereo/Mikansei/assets/52477630/b8b8b22d-723f-45ab-9b66-eea5486532fe)

### Summary of changes
- [x] Introduced the Java 8+ API desugaring
- [x] Refactored the date time converters
- [x] Migrated Date to OffsetDateTime on the features