### PR TITLE
Fix crash when entering Favorites page

### DIFF
--- a/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/DanbooruRepositoryImpl.kt
+++ b/core/danbooru/src/main/java/com/uragiristereo/mikansei/core/danbooru/DanbooruRepositoryImpl.kt
@@ -137,6 +137,7 @@ class DanbooruRepositoryImpl(
     }.mapSuccess {
         PostsResult(
             posts = it.toPostList(),
+            isEmpty = it.isEmpty(),
             canLoadMore = it.size == Constants.POSTS_PER_PAGE,
         )
     }

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/session/SessionDao.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/session/SessionDao.kt
@@ -1,6 +1,8 @@
 package com.uragiristereo.mikansei.core.database.session
 
 import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
@@ -9,6 +11,9 @@ import kotlinx.coroutines.flow.Flow
 interface SessionDao {
     @Query("select * from sessions_v2 where session_id = :sessionId")
     fun get(sessionId: String): Flow<SessionRow?>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun add(sessionRow: SessionRow)
 
     @Upsert
     suspend fun update(sessionRow: SessionRow)

--- a/core/database/src/main/java/com/uragiristereo/mikansei/core/database/session/SessionRepositoryImpl.kt
+++ b/core/database/src/main/java/com/uragiristereo/mikansei/core/database/session/SessionRepositoryImpl.kt
@@ -18,6 +18,10 @@ class SessionRepositoryImpl(
         }
     }
 
+    override suspend fun addSession(session: Session) {
+        sessionDao.add(session.toSessionRow())
+    }
+
     override suspend fun updateSession(session: Session) {
         sessionDao.update(session.toSessionRow())
     }

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/danbooru/entity/PostsResult.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/danbooru/entity/PostsResult.kt
@@ -2,8 +2,8 @@ package com.uragiristereo.mikansei.core.domain.module.danbooru.entity
 
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 
-
 data class PostsResult(
     val posts: List<Post>,
+    val isEmpty: Boolean,
     val canLoadMore: Boolean,
 )

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/danbooru/entity/PostsResult2.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/danbooru/entity/PostsResult2.kt
@@ -1,6 +1,0 @@
-package com.uragiristereo.mikansei.core.domain.module.danbooru.entity
-
-data class PostsResult2(
-    val isEmpty: Boolean,
-    val canLoadMore: Boolean,
-)

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/database/SessionRepository.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/module/database/SessionRepository.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.Flow
 interface SessionRepository {
     fun getSession(sessionId: String): Flow<Session?>
 
+    suspend fun addSession(session: Session)
+
     suspend fun updateSession(session: Session)
 
     fun getPosts(sessionId: String): Flow<List<Post>>

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetFavoritesAndFavoriteGroupsUseCase.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetFavoritesAndFavoriteGroupsUseCase.kt
@@ -14,10 +14,7 @@ class GetFavoritesAndFavoriteGroupsUseCase(
                 getFavoritesUseCase()
             },
             other = {
-                getFavoriteGroupsUseCase(
-                    forceCache = false,
-                    forceRefresh = true,
-                )
+                getFavoriteGroupsUseCase(forceRefresh = true)
             },
             transform = { result1, result2 ->
                 listOf(result1) + result2

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetFavoritesUseCase.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetFavoritesUseCase.kt
@@ -5,14 +5,12 @@ import com.uragiristereo.mikansei.core.domain.module.database.SessionRepository
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.model.result.mapSuccess
-import kotlinx.coroutines.flow.first
 import java.util.UUID
 
 class GetFavoritesUseCase(
     private val userRepository: UserRepository,
     private val sessionRepository: SessionRepository,
     private val getPostsUseCase: GetPostsUseCase,
-    private val filterPostsUseCase: FilterPostsUseCase,
 ) {
     suspend operator fun invoke(): Result<Favorite> {
         val activeUser = userRepository.active.value
@@ -23,16 +21,7 @@ class GetFavoritesUseCase(
             page = 1,
             sessionId = sessionId,
         ).mapSuccess { postsResult ->
-            val posts = when {
-                !postsResult.isEmpty -> {
-                    filterPostsUseCase(
-                        posts = sessionRepository.getPosts(sessionId).first(),
-                        tags = "",
-                    )
-                }
-
-                else -> emptyList()
-            }
+            val posts = postsResult.posts
 
             val thumbnailUrl = when {
                 posts.isNotEmpty() -> {

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetPostsUseCase.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetPostsUseCase.kt
@@ -4,6 +4,7 @@ import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.PostsResult
 import com.uragiristereo.mikansei.core.domain.module.database.PostRepository
 import com.uragiristereo.mikansei.core.domain.module.database.SessionRepository
+import com.uragiristereo.mikansei.core.domain.module.database.entity.Session
 import com.uragiristereo.mikansei.core.model.result.Result
 import com.uragiristereo.mikansei.core.model.result.mapSuccess
 import kotlinx.coroutines.flow.first
@@ -21,6 +22,8 @@ class GetPostsUseCase(
     ): Result<PostsResult> {
         return danbooruRepository.getPosts(tags, page)
             .mapSuccess { postsResult ->
+                sessionRepository.addSession(Session(id = sessionId, tags = tags))
+
                 // if page == 1, it means refreshing and existing posts should be cleared
                 val existingPosts = when {
                     page > 1 -> {

--- a/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetPostsUseCase.kt
+++ b/core/domain/src/main/java/com/uragiristereo/mikansei/core/domain/usecase/GetPostsUseCase.kt
@@ -1,7 +1,7 @@
 package com.uragiristereo.mikansei.core.domain.usecase
 
 import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
-import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.PostsResult2
+import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.PostsResult
 import com.uragiristereo.mikansei.core.domain.module.database.PostRepository
 import com.uragiristereo.mikansei.core.domain.module.database.SessionRepository
 import com.uragiristereo.mikansei.core.model.result.Result
@@ -18,7 +18,7 @@ class GetPostsUseCase(
         sessionId: String,
         tags: String,
         page: Int,
-    ): Result<PostsResult2> {
+    ): Result<PostsResult> {
         return danbooruRepository.getPosts(tags, page)
             .mapSuccess { postsResult ->
                 // if page == 1, it means refreshing and existing posts should be cleared
@@ -45,7 +45,8 @@ class GetPostsUseCase(
                     posts = existingPosts + newPosts,
                 )
 
-                PostsResult2(
+                PostsResult(
+                    posts = existingPosts + newPosts,
                     isEmpty = postsResult.posts.isEmpty(),
                     canLoadMore = canLoadMore,
                 )

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/FavoritesModule.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/FavoritesModule.kt
@@ -48,7 +48,7 @@ fun NavGraphBuilder.favoritesRoute(navController: NavHostController) {
                 onFavoriteClick = { id, username ->
                     val tags = when (id) {
                         0 -> "ordfav:$username "
-                        else -> "favgroup:$id "
+                        else -> "favgroup:$id status:any "
                     }
 
                     navController.navigate(HomeRoute.Posts(tags)) {

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/addto/AddToFavGroupViewModel.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/addto/AddToFavGroupViewModel.kt
@@ -54,10 +54,7 @@ class AddToFavGroupViewModel(
         viewModelScope.launch {
             isLoading = true
 
-            val result = getFavoriteGroupsUseCase(
-                forceCache = true,
-                forceRefresh = false,
-            )
+            val result = getFavoriteGroupsUseCase(forceRefresh = false)
 
             when (result) {
                 is Result.Success -> {
@@ -113,12 +110,7 @@ class AddToFavGroupViewModel(
                 isLoading = true
             }
 
-            val result = getFavoriteGroupsUseCase(
-                forceCache = true,
-                forceRefresh = true,
-            )
-
-            when (result) {
+            when (val result = getFavoriteGroupsUseCase(forceRefresh = true)) {
                 is Result.Success -> {
                     items = mapResult(result.data)
 

--- a/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/new/NewFavGroupViewModel.kt
+++ b/feature/home/favorites/src/main/java/com/uragiristereo/mikansei/feature/home/favorites/favgroup/new/NewFavGroupViewModel.kt
@@ -94,12 +94,7 @@ class NewFavGroupViewModel(
 
     private fun updateAndCacheFavoriteGroups() {
         viewModelScope.launch(SupervisorJob()) {
-            val result = getFavoriteGroupsUseCase(
-                forceCache = true,
-                forceRefresh = true,
-            )
-
-            when (result) {
+            when (val result = getFavoriteGroupsUseCase(forceRefresh = true)) {
                 is Result.Success -> Timber.d("updateAndCacheFavoriteGroups success")
                 is Result.Failed -> Timber.d(result.message)
                 is Result.Error -> Timber.d(result.t)


### PR DESCRIPTION
PR #25 introduced bugs again and hopefully this is the last one, this PR fixes forgot to add the session when getting post thumbnails on favorites. Also added `status:any` when browsing favorite groups, just like Danbooru.

### Summary of changes
- [x] Added function to add session
- [x] GetPostsUseCase now add the session into database first, ignore if it's exists
- [x] Refactored the favorite-related use cases