### PR TITLE
Fix post list crash caused by unsupported post type

### DIFF
--- a/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/Post.kt
+++ b/core/model/src/main/java/com/uragiristereo/mikansei/core/model/danbooru/Post.kt
@@ -51,6 +51,8 @@ data class Post(
         ANIMATED_GIF,
         VIDEO,
         UGOIRA,
+        FLASH,
+        UNSUPPORTED,
     }
 
     enum class Status {

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/composable/PostHeader.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/composable/PostHeader.kt
@@ -73,7 +73,7 @@ fun PostHeader(
             AsyncImage(
                 model = previewUrl,
                 contentDescription = null,
-                contentScale = ContentScale.FillWidth,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .height(72.dp)
                     .aspectRatio(aspectRatio)

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/ImageScreen.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/ImageScreen.kt
@@ -30,6 +30,7 @@ import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.LocalBottom
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.rememberModalBottomSheetState2
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
 import com.uragiristereo.mikansei.feature.image.image.ImagePost
+import com.uragiristereo.mikansei.feature.image.image.UnsupportedPost
 import com.uragiristereo.mikansei.feature.image.more.MoreBottomSheet
 import com.uragiristereo.mikansei.feature.image.video.VideoPost
 import kotlinx.coroutines.launch
@@ -133,6 +134,14 @@ internal fun ImageScreen(
                 onDownloadClick = {
                     lambdaOnDownload(viewModel.post)
                 },
+                onShareClick = lambdaOnShareClick,
+            )
+        }
+
+        Post.Type.FLASH, Post.Type.UNSUPPORTED -> {
+            UnsupportedPost(
+                onNavigateBack = onNavigateBack,
+                onMoreClick = lambdaOnMoreClick,
                 onShareClick = lambdaOnShareClick,
             )
         }

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/image/ImageViewModel.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/image/ImageViewModel.kt
@@ -1,13 +1,17 @@
 package com.uragiristereo.mikansei.feature.image.image
 
+import android.content.Context
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.core.Animatable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
+import com.uragiristereo.mikansei.core.domain.module.danbooru.DanbooruRepository
 import com.uragiristereo.mikansei.core.domain.module.danbooru.entity.Profile
 import com.uragiristereo.mikansei.core.domain.module.database.UserRepository
 import com.uragiristereo.mikansei.core.model.preferences.user.DetailSizePreference
@@ -19,6 +23,7 @@ import kotlinx.coroutines.flow.StateFlow
 class ImageViewModel(
     savedStateHandle: SavedStateHandle,
     private val userRepository: UserRepository,
+    danbooruRepository: DanbooruRepository,
 ) : ViewModel() {
     val post = savedStateHandle.toRoute<MainRoute.Image>(PostNavType).post
 
@@ -33,6 +38,9 @@ class ImageViewModel(
     val isGesturesAllowed by derivedStateOf {
         currentZoom == 1f
     }
+
+    private val customTabsIntentBuilder = CustomTabsIntent.Builder()
+    private val postLink = danbooruRepository.host.parsePostLink(post.id)
 
     fun onExpandImage() {
         expandButtonVisible = false
@@ -57,5 +65,11 @@ class ImageViewModel(
 
             else -> Pair(width, height)
         }
+    }
+
+    fun openPostInBrowser(context: Context) {
+        customTabsIntentBuilder
+            .build()
+            .launchUrl(context, postLink.toUri())
     }
 }

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/image/UnsupportedPost.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/image/UnsupportedPost.kt
@@ -1,0 +1,164 @@
+package com.uragiristereo.mikansei.feature.image.image
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.insets.ui.Scaffold
+import com.uragiristereo.mikansei.core.resources.R
+import com.uragiristereo.mikansei.core.ui.LocalLambdaOnDownload
+import com.uragiristereo.mikansei.core.ui.LocalScaffoldState
+import com.uragiristereo.mikansei.core.ui.LocalWindowSizeHorizontal
+import com.uragiristereo.mikansei.core.ui.WindowSize
+import com.uragiristereo.mikansei.feature.image.core.verticallyDraggable
+import com.uragiristereo.mikansei.feature.image.image.appbars.ImageBottomAppBar
+import com.uragiristereo.mikansei.feature.image.image.appbars.ImageTopAppBar
+import org.koin.androidx.compose.koinViewModel
+import kotlin.math.abs
+
+@Composable
+internal fun UnsupportedPost(
+    onNavigateBack: (Boolean) -> Unit,
+    onMoreClick: () -> Unit,
+    onShareClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ImageViewModel = koinViewModel(),
+) {
+    val context = LocalContext.current
+    val lambdaOnDownload = LocalLambdaOnDownload.current
+    val windowSizeHorizontal = LocalWindowSizeHorizontal.current
+
+    Scaffold(
+        scaffoldState = LocalScaffoldState.current,
+        topBar = {
+            AnimatedVisibility(
+                visible = true,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier
+                    .graphicsLayer {
+                        translationY = -abs(viewModel.offsetY.value)
+                    },
+            ) {
+                ImageTopAppBar(
+                    post = viewModel.post,
+                    expandLoadingVisible = false,
+                    expandButtonVisible = false,
+                    onNavigateBack = {
+                        onNavigateBack(/* navigatedBackByGesture = */ false)
+                    },
+                    onExpandClick = {},
+                    onDownloadClick = lambdaOnDownload,
+                    onShareClick = onShareClick,
+                    onMoreClick = onMoreClick,
+                )
+            }
+        },
+        bottomBar = {
+            AnimatedVisibility(
+                visible = windowSizeHorizontal == WindowSize.COMPACT,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier
+                    .graphicsLayer {
+                        translationY = abs(viewModel.offsetY.value)
+                    },
+            ) {
+                ImageBottomAppBar(
+                    post = viewModel.post,
+                    expandLoadingVisible = false,
+                    expandButtonVisible = false,
+                    onExpandClick = {},
+                    onDownloadClick = lambdaOnDownload,
+                    onShareClick = onShareClick,
+                )
+            }
+        },
+        contentPadding = PaddingValues(0.dp),
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .graphicsLayer {
+                    translationY = viewModel.offsetY.value
+                }
+                .pointerInput(key1 = Unit) {
+                    detectTapGestures(
+                        onLongPress = {
+                            onMoreClick()
+                        },
+                    )
+                }
+                .verticallyDraggable(
+                    enabled = true,
+                    offsetY = viewModel.offsetY,
+                    onDragExit = {
+                        onNavigateBack(true)
+                    },
+                )
+                .padding(all = 16.dp),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.image_not_supported),
+                contentDescription = null,
+                tint = MaterialTheme.colors.onPrimary,
+                modifier = Modifier
+                    .padding(bottom = 24.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colors.primary)
+                    .padding(16.dp)
+                    .size(48.dp),
+            )
+
+            Text(
+                text = "This post is not supported for viewing in Mikansei",
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 24.dp),
+            )
+
+            Button(
+                shape = RoundedCornerShape(percent = 50),
+                onClick = {
+                    viewModel.openPostInBrowser(context)
+                },
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.open_in_browser),
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+
+                Text(text = "Open in Browser")
+            }
+        }
+    }
+}


### PR DESCRIPTION
The mysterious random crash has been found, it was because of the `flash` post type. The Danbooru API doesn't return a `preview` media asset variation for the `flash` post type, so I need to handle it manually.

<img src="https://github.com/user-attachments/assets/1bd81700-22be-4c9d-887c-f8145210df32" alt="Screenshot_20250321-223052" width="30%" />

Currently Mikansei doesn't _yet_ support to view  `flash` post type, so instead I'm showing a placeholder when going into the post viewer.

<img src="https://github.com/user-attachments/assets/3b35e40f-553d-46b4-bc98-ac38d87f9207" alt="Screenshot_20250321-223056" width="30%" />

### Summary of changes
- [x] Added support for FLASH and UNSUPPORTED post type
- [x] Fixed PostHeader thumbnail content scaling