### PR TITLE
Implement tag actions

### DIFF
--- a/app/src/main/java/com/uragiristereo/mikansei/MikanseiModule.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/MikanseiModule.kt
@@ -8,6 +8,7 @@ import com.uragiristereo.mikansei.core.network.NetworkModule
 import com.uragiristereo.mikansei.core.preferences.PreferencesRepository
 import com.uragiristereo.mikansei.core.preferences.PreferencesRepositoryImpl
 import com.uragiristereo.mikansei.core.product.ProductModule
+import com.uragiristereo.mikansei.core.ui.shared.SharedViewModel
 import com.uragiristereo.mikansei.feature.about.aboutModule
 import com.uragiristereo.mikansei.feature.filters.FiltersViewModel
 import com.uragiristereo.mikansei.feature.home.HomeModule
@@ -56,5 +57,6 @@ object MikanseiModule {
         viewModelOf(::MoreViewModel)
         viewModelOf(::FiltersViewModel)
         viewModelOf(::SettingsViewModel)
+        viewModelOf(::SharedViewModel)
     }
 }

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/MainScreen.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/MainScreen.kt
@@ -36,6 +36,7 @@ import com.uragiristereo.mikansei.core.ui.LocalLambdaOnDownload
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnShare
 import com.uragiristereo.mikansei.core.ui.LocalScaffoldState
 import com.uragiristereo.mikansei.core.ui.LocalScrollToTopChannel
+import com.uragiristereo.mikansei.core.ui.LocalSharedViewModel
 import com.uragiristereo.mikansei.core.ui.LocalSnackbarHostState
 import com.uragiristereo.mikansei.core.ui.LocalWindowSizeHorizontal
 import com.uragiristereo.mikansei.core.ui.LocalWindowSizeVertical
@@ -48,6 +49,7 @@ import com.uragiristereo.mikansei.core.ui.navigation.NestedNavigationRoutes
 import com.uragiristereo.mikansei.core.ui.navigation.routeOf
 import com.uragiristereo.mikansei.core.ui.rememberWindowSizeHorizontal
 import com.uragiristereo.mikansei.core.ui.rememberWindowSizeVertical
+import com.uragiristereo.mikansei.core.ui.shared.SharedViewModel
 import com.uragiristereo.mikansei.ui.content.MainContentResponsive
 import com.uragiristereo.mikansei.ui.core.ShareDownloadDialog
 import com.uragiristereo.mikansei.ui.navgraphs.bottomNavGraph
@@ -66,6 +68,7 @@ fun MainScreen(
     val context = LocalContext.current
     val scaffoldState = rememberScaffoldState()
     val scope = rememberCoroutineScope()
+    val sharedViewModel = koinViewModel<SharedViewModel>()
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val backStack by navController.currentBackStack.collectAsState()
@@ -227,6 +230,7 @@ fun MainScreen(
                 LocalWindowSizeVertical provides rememberWindowSizeVertical(),
                 LocalScaffoldState provides scaffoldState,
                 LocalSnackbarHostState provides scaffoldState.snackbarHostState,
+                LocalSharedViewModel provides sharedViewModel,
             ),
         ) {
             SetSystemBarsColors(Color.Transparent)

--- a/app/src/main/java/com/uragiristereo/mikansei/ui/navgraphs/BottomNavGraph.kt
+++ b/app/src/main/java/com/uragiristereo/mikansei/ui/navgraphs/BottomNavGraph.kt
@@ -19,5 +19,5 @@ fun NavGraphBuilder.bottomNavGraph(
 
     savedSearchesBottomRoute(mainNavController)
 
-    imageBottomRoute()
+    imageBottomRoute(mainNavController)
 }

--- a/core/resources/src/main/res/drawable/content_copy.xml
+++ b/core/resources/src/main/res/drawable/content_copy.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,720q-33,0 -56.5,-23.5T280,640v-480q0,-33 23.5,-56.5T360,80h360q33,0 56.5,23.5T800,160v480q0,33 -23.5,56.5T720,720L360,720ZM360,640h360v-480L360,160v480ZM200,880q-33,0 -56.5,-23.5T120,800v-560h80v560h440v80L200,880ZM360,640v-480,480Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/core/resources/src/main/res/drawable/variable_add.xml
+++ b/core/resources/src/main/res/drawable/variable_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M560,680L120,680v-400h720v120h-80v-40L200,360v240h360v80ZM200,600v-240,240ZM760,800v-120L640,680v-80h120v-120h80v120h120v80L840,680v120h-80Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/core/resources/src/main/res/drawable/variable_insert.xml
+++ b/core/resources/src/main/res/drawable/variable_insert.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M120,680v-400h720v160h-80v-80L200,360v240h360v80L120,680ZM200,600v-240,240ZM864,800L720,657v123h-80v-260h260v80L776,600l144,144 -56,56Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/core/resources/src/main/res/drawable/variable_remove.xml
+++ b/core/resources/src/main/res/drawable/variable_remove.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M560,680L120,680v-400h720v120h-80v-40L200,360v240h360v80ZM200,600v-240,240ZM640,704 L724,620 640,536 696,480 780,564 864,480 920,536 837,620 920,704 864,760 780,677 696,760 640,704Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/CompositionLocals.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/CompositionLocals.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.model.danbooru.ShareOption
+import com.uragiristereo.mikansei.core.ui.shared.SharedViewModel
 import kotlinx.coroutines.channels.Channel
 
 val LocalLambdaOnDownload = compositionLocalOf<(Post) -> Unit> { error("no LocalLambdaOnDownload provided") }
@@ -15,3 +17,4 @@ val LocalScrollToTopChannel = compositionLocalOf<Channel<String>> { error("no Lo
 val LocalMainScaffoldPadding = compositionLocalOf { PaddingValues(0.dp) }
 val LocalScaffoldState = compositionLocalOf<ScaffoldState> { error("No LocalScaffoldState provided") }
 val LocalSnackbarHostState = compositionLocalOf<SnackbarHostState> { error("No LocalSnackbarHostState provided") }
+val LocalSharedViewModel = staticCompositionLocalOf<SharedViewModel> { error("No LocalSharedViewModel provided") }

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/modalbottomsheet/navigator/BottomSheetNavigator.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/modalbottomsheet/navigator/BottomSheetNavigator.kt
@@ -83,6 +83,16 @@ class BottomSheetNavigator internal constructor(
     suspend fun hideSheet() {
         sheetState.hide()
     }
+
+    fun navigateUp() {
+        if (!sheetState.isAnimationRunning && !sheetState.temporarilyHidden) {
+            coroutineScope.launch(SupervisorJob()) {
+                sheetState.hideTemporarily()
+                navController.popBackStack()
+                sheetState.expand()
+            }
+        }
+    }
 }
 
 @Composable
@@ -110,9 +120,7 @@ fun InterceptBackGestureForBottomSheetNavigator() {
             if (!sheetState.isAnimationRunning) {
                 scope.launch(SupervisorJob()) {
                     if (previousRoute !in listOf(null, indexId)) {
-                        sheetState.hideTemporarily()
-                        navController.popBackStack()
-                        sheetState.expand()
+                        bottomSheetNavigator.navigateUp()
                     } else {
                         sheetState.hide()
                     }

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/MainRoute.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/navigation/MainRoute.kt
@@ -44,6 +44,11 @@ sealed interface MainRoute : NavRoute {
     data class More(
         val post: Post,
     ) : MainRoute
+
+    @Serializable
+    data class TagActions(
+        val tag: String,
+    ) : MainRoute
 }
 
 val NestedNavigationRoutes = listOf(

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/shared/SharedViewModel.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/shared/SharedViewModel.kt
@@ -1,0 +1,10 @@
+package com.uragiristereo.mikansei.core.ui.shared
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class SharedViewModel : ViewModel() {
+    var currentTags by mutableStateOf("")
+}

--- a/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/core/PostsNavigation.kt
+++ b/feature/home/posts/src/main/java/com/uragiristereo/mikansei/feature/home/posts/core/PostsNavigation.kt
@@ -12,6 +12,7 @@ import androidx.navigation.toRoute
 import com.uragiristereo.mikansei.core.model.danbooru.Post
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnDownload
 import com.uragiristereo.mikansei.core.ui.LocalLambdaOnShare
+import com.uragiristereo.mikansei.core.ui.LocalSharedViewModel
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.InterceptBackGestureForBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.LocalBottomSheetNavigator
 import com.uragiristereo.mikansei.core.ui.navigation.HomeRoute
@@ -58,6 +59,7 @@ fun NavGraphBuilder.postsRoute(
         },
     ) { entry ->
         val bottomSheetNavigator = LocalBottomSheetNavigator.current
+        val sharedViewModel = LocalSharedViewModel.current
 
         val isRouteFirstEntry = remember {
             // 3 from list of null, MainRoute.Home, HomeRoute.Posts
@@ -68,6 +70,7 @@ fun NavGraphBuilder.postsRoute(
 
         LaunchedEffect(key1 = args.tags) {
             onCurrentTagsChange(args.tags)
+            sharedViewModel.currentTags = args.tags
         }
 
         PostsScreen(

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheet.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/MoreBottomSheet.kt
@@ -61,6 +61,7 @@ internal fun MoreBottomSheet(
     onExpandClick: () -> Unit,
     onAddToClick: (Post) -> Unit,
     onShareClick: (Post) -> Unit,
+    onTagClick: (String) -> Unit,
     viewModel: MoreBottomSheetViewModel = koinViewModel(),
 ) {
     val context = LocalContext.current
@@ -242,6 +243,7 @@ internal fun MoreBottomSheet(
                     MoreTagsRow(
                         tags = viewModel.tags,
                         tagsCount = tagsCount,
+                        onTagClick = onTagClick,
                         modifier = Modifier
                             .padding(bottom = 16.dp)
                             .windowInsetsPadding(WindowInsets.navigationBarsIgnoringVisibility),

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/tags/MoreTagsRow.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/tags/MoreTagsRow.kt
@@ -23,6 +23,7 @@ import com.uragiristereo.mikansei.core.resources.R
 internal fun MoreTagsRow(
     tags: SnapshotStateList<Tag>,
     tagsCount: Int,
+    onTagClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -50,7 +51,9 @@ internal fun MoreTagsRow(
                 MoreTagItem(
                     tag = tag,
                     selected = false,
-                    onSelectedChange = { },
+                    onSelectedChange = {
+                        onTagClick(tag.name)
+                    },
                     modifier = Modifier.padding(bottom = 12.dp),
                 )
             }

--- a/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/tags/TagActionsBottomSheet.kt
+++ b/feature/image/src/main/java/com/uragiristereo/mikansei/feature/image/more/tags/TagActionsBottomSheet.kt
@@ -1,0 +1,207 @@
+package com.uragiristereo.mikansei.feature.image.more.tags
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.uragiristereo.mikansei.core.resources.R
+import com.uragiristereo.mikansei.core.ui.composable.ClickableSection
+import com.uragiristereo.mikansei.core.ui.extension.copyToClipboard
+import com.uragiristereo.mikansei.core.ui.modalbottomsheet.navigator.bottomSheetContentPadding
+import kotlinx.coroutines.launch
+
+@Composable
+fun TagActionsBottomSheet(
+    tag: String,
+    currentSearchTags: String,
+    onDismiss: suspend () -> Unit,
+    onNavigateBack: () -> Unit,
+    onAddToExisting: (searchImmediately: Boolean) -> Unit,
+    onExcludeToExisting: (searchImmediately: Boolean) -> Unit,
+    onNewSearch: (searchImmediately: Boolean) -> Unit,
+) {
+    val context = LocalContext.current
+    val hapticFeedback = LocalHapticFeedback.current
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Vertical))
+            .bottomSheetContentPadding(),
+    ) {
+        IconButton(
+            onClick = onNavigateBack,
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .padding(bottom = 8.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colors.background.copy(alpha = ContentAlpha.medium)),
+            content = {
+                Icon(
+                    painter = painterResource(id = R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            },
+        )
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = 16.dp,
+                    end = 8.dp,
+                    bottom = 8.dp,
+                ),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Tag Actions",
+                    style = MaterialTheme.typography.subtitle1,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colors.primary.copy(alpha = 0.87f),
+                )
+
+                Text(
+                    text = tag,
+                    color = LocalContentColor.current.copy(alpha = ContentAlpha.medium),
+                )
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            IconButton(
+                onClick = {
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                    context.copyToClipboard(
+                        text = tag,
+                        message = "Tag copied to clipboard!",
+                    )
+                },
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.content_copy),
+                    contentDescription = null,
+                )
+            }
+        }
+
+        Divider()
+
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 8.dp),
+        ) {
+            ClickableSection(
+                title = "Add to existing search",
+                subtitle = buildAnnotatedString {
+                    append(currentSearchTags)
+
+                    withStyle(
+                        style = SpanStyle(
+                            color = MaterialTheme.colors.primary,
+                            fontWeight = FontWeight.Medium,
+                        ),
+                    ) {
+                        append(tag)
+                    }
+                },
+                icon = painterResource(R.drawable.variable_insert),
+                onClick = {
+                    scope.launch {
+                        onDismiss()
+                        onAddToExisting(true)
+                    }
+                },
+                onLongClick = {
+                    scope.launch {
+                        onDismiss()
+                        onAddToExisting(false)
+                    }
+                },
+            )
+
+            ClickableSection(
+                title = "Exclude from existing search",
+                subtitle = buildAnnotatedString {
+                    append(currentSearchTags)
+
+                    withStyle(
+                        style = SpanStyle(
+                            color = MaterialTheme.colors.error,
+                            fontWeight = FontWeight.Medium,
+                        ),
+                    ) {
+                        append("-$tag")
+                    }
+                },
+                icon = painterResource(R.drawable.variable_remove),
+                onClick = {
+                    scope.launch {
+                        onDismiss()
+                        onExcludeToExisting(true)
+                    }
+                },
+                onLongClick = {
+                    scope.launch {
+                        onDismiss()
+                        onExcludeToExisting(false)
+                    }
+                },
+            )
+
+            ClickableSection(
+                title = "New search from this tag",
+                icon = painterResource(R.drawable.variable_add),
+                onClick = {
+                    scope.launch {
+                        onDismiss()
+                        onNewSearch(true)
+                    }
+                },
+                onLongClick = {
+                    scope.launch {
+                        onDismiss()
+                        onNewSearch(false)
+                    }
+                },
+            )
+        }
+    }
+}


### PR DESCRIPTION
Upon clicking a tag within post detail bottom sheet, there will be a new bottom sheet of the actions that can be performed of a tag. I'm currently adding these actions: copy, add to existing search, exclude to existing search, and new search. The bottom sheet is able to return to post detail bottom sheet, so adding a back button is mandatory.

<img src="https://github.com/user-attachments/assets/a6bf3f39-0751-4d47-a9d5-9c685b34e46c" width="30%" />

### Summary of changes
- [x] Implemented the bottom sheet
- [x] Enhance and update the usages