### PR TITLE
Interop Views EditText for Search Bar

### DIFF
--- a/core/ui/build.gradle
+++ b/core/ui/build.gradle
@@ -35,4 +35,5 @@ dependencies {
     implementation(libs.timber)
     api(libs.androidx.navigation)
     implementation(libs.bundles.coil)
+    implementation(libs.bundles.core)
 }

--- a/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/view/SelectionAwareEditText.kt
+++ b/core/ui/src/main/java/com/uragiristereo/mikansei/core/ui/view/SelectionAwareEditText.kt
@@ -1,0 +1,50 @@
+package com.uragiristereo.mikansei.core.ui.view
+
+import android.content.Context
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatEditText
+
+class SelectionAwareEditText @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle,
+) : AppCompatEditText(context, attrs, defStyleAttr) {
+    private lateinit var selectionChangeListeners: MutableSet<SelectionTextWatcher>
+
+    private fun getOrCreateSelectionChangeListeners(): MutableSet<SelectionTextWatcher> {
+        if (!::selectionChangeListeners.isInitialized) {
+            selectionChangeListeners = mutableSetOf()
+        }
+        return selectionChangeListeners
+    }
+
+    fun addSelectionTextChangedListener(listener: SelectionTextWatcher) {
+        getOrCreateSelectionChangeListeners().add(listener)
+        addTextChangedListener(listener)
+    }
+
+    fun removeSelectionTextChangedListener(listener: SelectionTextWatcher) {
+        getOrCreateSelectionChangeListeners().remove(listener)
+        removeTextChangedListener(listener)
+    }
+
+    override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+        super.onSelectionChanged(selStart, selEnd)
+
+        getOrCreateSelectionChangeListeners().forEach { listener ->
+            listener.onSelectionChanged(selStart, selEnd)
+        }
+    }
+}
+
+interface SelectionTextWatcher : TextWatcher {
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+    override fun afterTextChanged(s: Editable?) {}
+
+    fun onSelectionChanged(selStart: Int, selEnd: Int) {}
+}

--- a/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/SearchScreen.kt
@@ -1,5 +1,10 @@
 package com.uragiristereo.mikansei.feature.search
 
+import android.text.InputType
+import android.util.TypedValue
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -25,12 +30,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
+import androidx.core.view.setPadding
 import com.google.accompanist.insets.ui.Scaffold
 import com.uragiristereo.mikansei.core.product.component.ProductNavigationBarSpacer
 import com.uragiristereo.mikansei.core.product.component.ProductStatusBarSpacer
@@ -38,6 +45,7 @@ import com.uragiristereo.mikansei.core.resources.R
 import com.uragiristereo.mikansei.core.ui.LocalScaffoldState
 import com.uragiristereo.mikansei.core.ui.extension.backgroundElevation
 import com.uragiristereo.mikansei.core.ui.extension.copy
+import com.uragiristereo.mikansei.core.ui.view.SelectionAwareEditText
 import com.uragiristereo.mikansei.feature.search.browse_chips.BrowseChips
 import com.uragiristereo.mikansei.feature.search.core.SearchBar
 import com.uragiristereo.mikansei.feature.search.quick_shortcut_bar.SearchQuickShortcutBar
@@ -55,13 +63,37 @@ internal fun SearchScreen(
     onSearchSubmit: (String) -> Unit,
     viewModel: SearchViewModel = koinViewModel(),
 ) {
+    val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val scaffoldState = LocalScaffoldState.current
+    val editText = remember(context) {
+        SelectionAwareEditText(context).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            imeOptions = EditorInfo.IME_ACTION_SEARCH or EditorInfo.IME_FLAG_NO_FULLSCREEN
+            inputType = InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            isSingleLine = true
+            setBackgroundResource(android.R.color.transparent)
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
+            setPadding(0)
+        }
+    }
 
     val scope = rememberCoroutineScope()
     val columnState = rememberLazyListState()
     val browseChips by viewModel.browseChips.collectAsState()
-    val focusRequester = remember { FocusRequester() }
+
+    fun showKeyboard() {
+        context.getSystemService<InputMethodManager>()?.showSoftInput(editText, 0)
+    }
+
+    fun hideKeyboard() {
+        context.getSystemService<InputMethodManager>()
+            ?.hideSoftInputFromWindow(editText.windowToken, 0)
+        keyboardController?.hide()
+    }
 
     LaunchedEffect(key1 = viewModel.loading) {
         if (!viewModel.loading) {
@@ -88,7 +120,7 @@ internal fun SearchScreen(
 
     LaunchedEffect(key1 = columnState.isScrollInProgress) {
         if (columnState.isScrollInProgress && viewModel.searches.isNotEmpty()) {
-            keyboardController?.hide()
+            hideKeyboard()
         }
     }
 
@@ -107,15 +139,19 @@ internal fun SearchScreen(
         topBar = {
             ProductStatusBarSpacer {
                 SearchBar(
+                    editText = editText,
                     query = viewModel.query,
                     placeholder = stringResource(id = R.string.field_placeholder_example),
                     loading = viewModel.loading,
-                    focusRequester = focusRequester,
-                    onNavigateBack = onNavigateBack,
+                    onNavigateBack = {
+                        hideKeyboard()
+                        onNavigateBack()
+                    },
                     onQueryChange = {
                         viewModel.query = it.copy(text = it.text.lowercase())
                     },
                     onQuerySubmit = {
+                        hideKeyboard()
                         onSearchSubmit(viewModel.parsedQuery)
                     },
                     onClearClick = {
@@ -157,6 +193,7 @@ internal fun SearchScreen(
                 BrowseChips(
                     chips = browseChips,
                     onClick = {
+                        hideKeyboard()
                         onSearchSubmit(viewModel.parsedQuery)
                     },
                 )
@@ -197,8 +234,8 @@ internal fun SearchScreen(
                                 viewModel.searchAllowed = true
                                 viewModel.searchTerm()
 
-                                focusRequester.requestFocus()
-                                keyboardController?.show()
+                                editText.requestFocus()
+                                showKeyboard()
                             }
                         },
                         onLongClick = { /*TODO*/ },
@@ -210,12 +247,12 @@ internal fun SearchScreen(
 
     DisposableEffect(key1 = viewModel) {
         scope.launch {
-            focusRequester.requestFocus()
-            keyboardController?.show()
+            editText.requestFocus()
+            showKeyboard()
         }
 
         onDispose {
-            keyboardController?.hide()
+            editText.clearFocus()
         }
     }
 }

--- a/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/core/SearchBar.kt
+++ b/feature/search/src/main/java/com/uragiristereo/mikansei/feature/search/core/SearchBar.kt
@@ -1,41 +1,42 @@
 package com.uragiristereo.mikansei.feature.search.core
 
+import android.view.inputmethod.EditorInfo
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import com.uragiristereo.mikansei.core.resources.R
 import com.uragiristereo.mikansei.core.ui.extension.backgroundElevation
+import com.uragiristereo.mikansei.core.ui.view.SelectionAwareEditText
+import com.uragiristereo.mikansei.core.ui.view.SelectionTextWatcher
 
 @Composable
 internal fun SearchBar(
+    editText: SelectionAwareEditText,
     query: TextFieldValue,
     loading: Boolean,
     onQueryChange: (TextFieldValue) -> Unit,
@@ -44,98 +45,137 @@ internal fun SearchBar(
     onClearClick: () -> Unit,
     modifier: Modifier = Modifier,
     placeholder: String = "",
-    focusRequester: FocusRequester = remember { FocusRequester() },
 ) {
+    val contentColor = MaterialTheme.colors.onSurface
+    val highContentColor = contentColor.copy(alpha = ContentAlpha.high)
+    val mediumContentColor = contentColor.copy(alpha = ContentAlpha.medium)
+
+    val textWatcher = remember {
+        object : SelectionTextWatcher {
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                onQueryChange(
+                    TextFieldValue(
+                        text = s?.toString().orEmpty(),
+                        selection = TextRange(
+                            start = editText.selectionStart,
+                            end = editText.selectionEnd,
+                        )
+                    )
+                )
+            }
+
+            override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+                onQueryChange(
+                    TextFieldValue(
+                        text = editText.text?.toString().orEmpty(),
+                        selection = TextRange(
+                            start = selStart,
+                            end = selEnd,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
     Column(
         modifier = modifier.fillMaxWidth(),
     ) {
-        TextField(
-            value = query,
-            onValueChange = onQueryChange,
-            placeholder = {
-                Text(text = placeholder)
-            },
-            leadingIcon = {
-                IconButton(
-                    onClick = onNavigateBack,
-                    content = {
-                        Icon(
-                            painter = painterResource(id = R.drawable.arrow_back),
-                            contentDescription = null,
-                        )
-                    },
-                )
-            },
-            trailingIcon = {
-                Row {
-                    if (query.text.isNotEmpty()) {
-                        IconButton(
-                            onClick = onClearClick,
-                            content = {
-                                AnimatedVisibility(
-                                    visible = loading,
-                                    enter = fadeIn(),
-                                    exit = fadeOut(),
-                                    content = {
-                                        CircularProgressIndicator(
-                                            strokeWidth = 2.dp,
-                                            color = MaterialTheme.colors.secondary,
-                                            modifier = Modifier.size(26.dp),
-                                        )
-                                    },
-                                )
-
-                                Icon(
-                                    painter = painterResource(id = R.drawable.close),
-                                    contentDescription = stringResource(id = R.string.clear_action),
-                                )
-                            },
-                        )
-                    }
-
-//                    IconButton(
-//                        onClick = {
-//                            onActionsRowExpandedChange(!actionsRowExpanded)
-//                        },
-//                        content = {
-//                            Icon(
-//                                painter = painterResource(
-//                                    id = when {
-//                                        actionsRowExpanded -> R.drawable.expand_less
-//                                        else -> R.drawable.expand_more
-//                                    },
-//                                ),
-//                                contentDescription = null,
-//                            )
-//                        },
-//                    )
-                }
-            },
-            colors = TextFieldDefaults.textFieldColors(
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent,
-                disabledIndicatorColor = Color.Transparent,
-                backgroundColor = Color.Transparent,
-            ),
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Search,
-                keyboardType = KeyboardType.Uri,
-                autoCorrect = false,
-            ),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    onQuerySubmit(query)
-                },
-            ),
-            singleLine = true,
-            shape = RectangleShape,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .fillMaxWidth()
+                .height(56.dp)
                 .background(
                     color = MaterialTheme.colors.background.backgroundElevation(),
                 )
-                .focusRequester(focusRequester),
-        )
+                .padding(horizontal = 4.dp),
+        ) {
+            IconButton(
+                onClick = onNavigateBack,
+                content = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.arrow_back),
+                        contentDescription = null,
+                        tint = highContentColor,
+                    )
+                },
+            )
+
+            AndroidView(
+                factory = {
+                    editText.apply {
+                        addSelectionTextChangedListener(textWatcher)
+                        setOnEditorActionListener { _, actionId, _ ->
+                            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                                onQuerySubmit(query)
+                                return@setOnEditorActionListener true
+                            }
+
+                            false
+                        }
+                    }
+                },
+                update = {
+                    it.apply {
+                        setHint(placeholder)
+                        setTextColor(highContentColor.toArgb())
+                        setHintTextColor(mediumContentColor.toArgb())
+
+                        val value = TextFieldValue(
+                            text = text.toString(),
+                            selection = TextRange(
+                                start = selectionStart,
+                                end = selectionEnd
+                            ),
+                        )
+                        if (query.text != value.text) {
+                            editText.removeSelectionTextChangedListener(textWatcher)
+                            setText(query.text)
+                            setSelection(query.selection.start, query.selection.end)
+                            editText.addSelectionTextChangedListener(textWatcher)
+                        } else {
+                            if (query.selection != value.selection) {
+                                editText.removeSelectionTextChangedListener(textWatcher)
+                                setSelection(query.selection.start, query.selection.end)
+                                editText.addSelectionTextChangedListener(textWatcher)
+                            }
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .padding(4.dp)
+                    .padding(start = 16.dp)
+                    .weight(1f, fill = true),
+            )
+
+            if (query.text.isNotEmpty()) {
+                IconButton(
+                    onClick = onClearClick,
+                    content = {
+                        AnimatedVisibility(
+                            visible = loading,
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                            content = {
+                                CircularProgressIndicator(
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colors.secondary,
+                                    modifier = Modifier.size(26.dp),
+                                )
+                            },
+                        )
+
+                        Icon(
+                            painter = painterResource(id = R.drawable.close),
+                            contentDescription = stringResource(id = R.string.clear_action),
+                            tint = mediumContentColor,
+                        )
+                    },
+                )
+            } else {
+                Spacer(Modifier.size(24.dp))
+            }
+        }
 
         Divider()
     }


### PR DESCRIPTION
This adds a double-tap gesture to select the word, it's useful when editing the tags to be able to delete a tag quickly. As for now, the current Compose TextField implementation doesn't provide such feature, so I need to interop the EditText from the Views system, it works okay but kinda hacky in general to match the existing search screen implementation.

https://github.com/user-attachments/assets/06bf0a2d-2e16-4419-8d24-2a006e2ea2dc

### Summary of changes
- [x] Implemented SelectionAwareEditText
- [x] Refactored the SearchBar to use EditText

### TODO
- [ ] Find a way to change the cursor color & context menu theme